### PR TITLE
Adding timestamps fields in Blueprint statement. closes #14

### DIFF
--- a/src/masonite/orm/blueprint/Blueprint.py
+++ b/src/masonite/orm/blueprint/Blueprint.py
@@ -18,6 +18,8 @@ class Column:
         self.after_column = None
         self.old_column = ""
         self._action = action
+        self.current_timestamp = False
+        self.default_value = None
 
     def nullable(self):
         self.is_null = True
@@ -40,6 +42,13 @@ class Column:
         self.after_column = after_column
         return self
 
+    def use_current(self):
+        self.use_current = True
+        return self
+
+    def default(self, value=None):
+        if value:
+            self.default_value = value
 
 class Blueprint:
     def __init__(self, grammar, table="", action=None, default_string_length=None):
@@ -111,6 +120,14 @@ class Blueprint:
     def datetime(self, column, nullable=False):
         self._last_column = self.new_column("datetime", column, None, nullable)
         self._columns += (self._last_column,)
+        return self
+
+    def timestamps(self):
+        created_at = self.new_column('timestamp', 'created_at', None, nullable=False).use_current()
+        updated_at = self.new_column('timestamp', 'updated_at', None, nullable=False).use_current()
+
+        self._last_column = updated_at
+        self._columns += (created_at, updated_at,)
         return self
 
     def decimal(self, column, length=17, precision=6, nullable=False):

--- a/src/masonite/orm/blueprint/Blueprint.py
+++ b/src/masonite/orm/blueprint/Blueprint.py
@@ -17,9 +17,9 @@ class Column:
         self.constraint_type = None
         self.after_column = None
         self.old_column = ""
-        self._action = action
-        self.current_timestamp = False
+        self.use_current_timestamp = False
         self.default_value = None
+        self._action = action
 
     def nullable(self):
         self.is_null = True
@@ -42,13 +42,13 @@ class Column:
         self.after_column = after_column
         return self
 
-    def use_current(self):
-        self.use_current = True
+    def default(self, value):
+        self.default_value = value
         return self
 
-    def default(self, value=None):
-        if value:
-            self.default_value = value
+    def use_current(self):
+        self.use_current_timestamp = True
+        return self
 
 class Blueprint:
     def __init__(self, grammar, table="", action=None, default_string_length=None):
@@ -119,6 +119,11 @@ class Blueprint:
 
     def datetime(self, column, nullable=False):
         self._last_column = self.new_column("datetime", column, None, nullable)
+        self._columns += (self._last_column,)
+        return self
+
+    def timestamp(self, column, nullable=False):
+        self._last_column = self.new_column("timestamp", column, None, nullable)
         self._columns += (self._last_column,)
         return self
 

--- a/src/masonite/orm/grammar/mysql_grammar.py
+++ b/src/masonite/orm/grammar/mysql_grammar.py
@@ -63,6 +63,11 @@ class MySQLGrammar(BaseGrammar):
         "unsigned_integer": "UNSIGNED INT",
     }
 
+    temporal_field_defaults = {
+        "timestamp": "CURRENT_TIMESTAMP",
+        "datetime": "NOW()"
+    }
+
     def select_format(self):
         return "SELECT {columns} FROM {table} {joins} {wheres} {group_by}{order_by}{limit} {having}"
 
@@ -104,7 +109,10 @@ class MySQLGrammar(BaseGrammar):
 
     def create_column_string(self):
         return "{column} {data_type}{length}{nullable}, "
-
+    
+    def create_column_string_with_default(self):
+        return "{column} {data_type}{length} DEFAULT {default_value}, "
+    
     def column_exists_string(self):
         return "SHOW COLUMNS FROM {table} LIKE {value}"
 
@@ -185,6 +193,3 @@ class MySQLGrammar(BaseGrammar):
 
     def drop_table_if_exists_string(self):
         return "DROP TABLE IF EXISTS {table}"
-
-    def timestamp_column(self):
-        return "TIMESTAMP"

--- a/src/masonite/orm/grammar/mysql_grammar.py
+++ b/src/masonite/orm/grammar/mysql_grammar.py
@@ -185,3 +185,6 @@ class MySQLGrammar(BaseGrammar):
 
     def drop_table_if_exists_string(self):
         return "DROP TABLE IF EXISTS {table}"
+
+    def timestamp_column(self):
+        return "TIMESTAMP"

--- a/tests/schema/mysql/test_mysql_schema.py
+++ b/tests/schema/mysql/test_mysql_schema.py
@@ -313,7 +313,6 @@ class TestMySQLCreateGrammar(BaseTestCreateGrammar, unittest.TestCase):
     def can_compile_timestamps_columns(self):
         """
         with self.schema.create('users') as blueprint:
-            blueprint.string("name)
             blueprint.timestamps()
         """
 

--- a/tests/schema/mysql/test_mysql_schema.py
+++ b/tests/schema/mysql/test_mysql_schema.py
@@ -113,6 +113,12 @@ class BaseTestCreateGrammar:
         sql = getattr(self, inspect.currentframe().f_code.co_name.replace('test_', ''))()
         self.assertEqual(blueprint.to_sql(), sql)
 
+    def test_can_compile_timestamps_columns(self):
+        with self.schema.create('users') as blueprint:
+            blueprint.timestamps()
+
+        sql = getattr(self, inspect.currentframe().f_code.co_name.replace('test_', ''))()
+        self.assertEqual(blueprint.to_sql(), sql)
 
 class TestMySQLCreateGrammar(BaseTestCreateGrammar, unittest.TestCase):
 
@@ -303,3 +309,17 @@ class TestMySQLCreateGrammar(BaseTestCreateGrammar, unittest.TestCase):
                 "ADD `name` VARCHAR(191) NOT NULL")
 
         self.assertEqual(blueprint.to_sql(), sql)
+
+    def can_compile_timestamps_columns(self):
+        """
+        with self.schema.create('users') as blueprint:
+            blueprint.string("name)
+            blueprint.timestamps()
+        """
+
+        return (
+            "CREATE TABLE `users` ("
+                "`created_at` TIMESTAMP NOT NULL, "
+                "`updated_at` TIMESTAMP NOT NULL"
+            ")"
+        )

--- a/tests/schema/mysql/test_mysql_schema.py
+++ b/tests/schema/mysql/test_mysql_schema.py
@@ -113,12 +113,37 @@ class BaseTestCreateGrammar:
         sql = getattr(self, inspect.currentframe().f_code.co_name.replace('test_', ''))()
         self.assertEqual(blueprint.to_sql(), sql)
 
-    def test_can_compile_timestamps_columns(self):
+    def test_can_compile_timestamps_columns_with_default(self):
         with self.schema.create('users') as blueprint:
             blueprint.timestamps()
 
         sql = getattr(self, inspect.currentframe().f_code.co_name.replace('test_', ''))()
         self.assertEqual(blueprint.to_sql(), sql)
+
+    def test_can_compile_timestamp_column_without_default(self):
+        with self.schema.create('users') as blueprint:
+            blueprint.timestamp('logged_at')
+
+        sql = getattr(self, inspect.currentframe().f_code.co_name.replace('test_', ''))()
+        self.assertEqual(blueprint.to_sql(), sql)
+
+    def test_can_compile_timestamps_columns_mixed_defaults_and_not_default(self):
+        with self.schema.create('users') as blueprint:
+            blueprint.timestamps()
+            blueprint.timestamp('logged_at')
+            blueprint.timestamp('expirated_at')
+
+        sql = getattr(self, inspect.currentframe().f_code.co_name.replace('test_', ''))()
+        self.assertEqual(blueprint.to_sql(), sql)
+
+    def test_can_compile_timestamp_nullable_columns(self):
+        with self.schema.create('users') as blueprint:
+            blueprint.timestamp('logged_at')
+            blueprint.timestamp('expirated_at').nullable()
+
+        sql = getattr(self, inspect.currentframe().f_code.co_name.replace('test_', ''))()
+        self.assertEqual(blueprint.to_sql(), sql)
+
 
 class TestMySQLCreateGrammar(BaseTestCreateGrammar, unittest.TestCase):
 
@@ -310,7 +335,7 @@ class TestMySQLCreateGrammar(BaseTestCreateGrammar, unittest.TestCase):
 
         self.assertEqual(blueprint.to_sql(), sql)
 
-    def can_compile_timestamps_columns(self):
+    def can_compile_timestamps_columns_with_default(self):
         """
         with self.schema.create('users') as blueprint:
             blueprint.timestamps()
@@ -318,7 +343,50 @@ class TestMySQLCreateGrammar(BaseTestCreateGrammar, unittest.TestCase):
 
         return (
             "CREATE TABLE `users` ("
-                "`created_at` TIMESTAMP NOT NULL, "
-                "`updated_at` TIMESTAMP NOT NULL"
+                "`created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                "`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+            ")"
+        )
+
+    def can_compile_timestamp_column_without_default(self):
+        """
+        with self.schema.create('users') as blueprint:
+            blueprint.timestamp('logged_at')
+        """
+
+        return (
+            "CREATE TABLE `users` ("
+                "`logged_at` TIMESTAMP NOT NULL"
+            ")"
+        )
+
+    def can_compile_timestamps_columns_mixed_defaults_and_not_default(self):
+        """
+        with self.schema.create('users') as blueprint:
+            blueprint.timestamps()
+            blueprint.timestamp('logged_at')
+            blueprint.timestamp('expirated_at')
+        """
+
+        return (
+            "CREATE TABLE `users` ("
+                "`created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                "`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                "`logged_at` TIMESTAMP NOT NULL, "
+                "`expirated_at` TIMESTAMP NOT NULL"
+            ")"
+        )
+
+    def test_can_compile_timestamp_nullable_columns(self):
+        """
+        with self.schema.create('users') as blueprint:
+            blueprint.timestamp('logged_at')
+            blueprint.timestamp('expirated_at').nullable()
+        """
+
+        return (
+            "CREATE TABLE `users` ("
+                "`logged_at` TIMESTAMP NOT NULL, "
+                "`expirated_at` TIMESTAMP"
             ")"
         )


### PR DESCRIPTION
Some steps are done to declare timestamp fields using Blueprint statement.

- [x] Create a basic declaration on create table ( without: default values, time zones )
- [x] **.use_current()** method to define whether call "CURRENT_TIMESTAMP" statement in query. 
- [x] Decide if **default()** method will be used. Setting to "CURRENT_TIMESTAMP".
- [x] Add the **nullable()** method in **timestamp** column type.

To update the **updated_at** field in MySQL there's the "ON UPDATE" to update the field by a trigger. Will this done by an update in python code or SQL statement?
