### PR TITLE
added accessor

### DIFF
--- a/tests/grammar/mssql/test_mssql_select_grammer.py
+++ b/tests/grammar/mssql/test_mssql_select_grammer.py
@@ -204,13 +204,11 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammer, unittest.TestCase):
         """
         return "SELECT * FROM [users] WHERE [age] NOT BETWEEN '18' AND '21'"
 
-
     def can_compile_where_not_in(self):
         """
         self.builder.select('username').where_not_in('age', [1,2,3]).to_sql() 
         """
         return "SELECT [username] FROM [users] WHERE [age] NOT IN ('1','2','3')"
-
 
     def can_compile_having_with_expression(self):
         """

--- a/tests/grammar/mysql/test_relationships.py
+++ b/tests/grammar/mysql/test_relationships.py
@@ -24,6 +24,9 @@ if os.getenv("RUN_MYSQL_DATABASE", False) == "True":
         def articles(self):
             return Articles
 
+        def get_is_admin(self):
+            return "You are an admin"
+
     class TestRelationships(unittest.TestCase):
         def test_relationship_can_be_callable(self):
             self.assertEqual(


### PR DESCRIPTION
Accessors for this ORM will be a bit different than Orator. Right now orator does something like:

```python
class User:

    @accessor
    def is_admin(self):
        return 'user is admin'
```

This ORM will be this:

```python
class User:

    def get_is_admin(self):
        return 'user is admin'
```
