### PR TITLE
Schema: Rename table

### DIFF
--- a/src/masonite/orm/grammar/BaseGrammar.py
+++ b/src/masonite/orm/grammar/BaseGrammar.py
@@ -537,3 +537,9 @@ class BaseGrammar:
             table=self._compile_column(table)
         )
         return self
+
+    def rename_table(self, current_name, new_name):
+        self._sql = self.rename_table_string().format(
+            current_name=self._compile_column(current_name),
+            new_name=self._compile_column(new_name))
+        return self

--- a/src/masonite/orm/grammar/mysql_grammar.py
+++ b/src/masonite/orm/grammar/mysql_grammar.py
@@ -202,3 +202,6 @@ class MySQLGrammar(BaseGrammar):
 
     def drop_table_if_exists_string(self):
         return "DROP TABLE IF EXISTS {table}"
+
+    def rename_table_string(self):
+        return "RENAME TABLE {current_name} TO {new_name}"

--- a/src/masonite/orm/schema/Schema.py
+++ b/src/masonite/orm/schema/Schema.py
@@ -99,3 +99,11 @@ class Schema:
         if query_only:
             return query
         return bool(cls._connection().make_connection().query(query, ()))
+
+    @classmethod
+    def rename(cls, table, new_name, query_only=False):
+        grammar = cls._connection.get_grammer()(table=table)
+        query = grammar.rename_table(current_name=table, new_name=new_name).to_sql()
+        if query_only:
+            return query
+        return bool(cls._connection().make_connection().query(query, ()))

--- a/tests/schema/mysql/test_mysql_schema.py
+++ b/tests/schema/mysql/test_mysql_schema.py
@@ -197,6 +197,14 @@ class BaseTestCreateGrammar:
         )()
         self.assertEqual(blueprint.to_sql(), sql)
 
+    def test_rename_table(self):
+        to_sql = self.schema.rename("users", "core", query_only=True)
+
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(to_sql, sql)
+
 
 class TestMySQLCreateGrammar(BaseTestCreateGrammar, unittest.TestCase):
     def setUp(self):
@@ -449,3 +457,10 @@ class TestMySQLCreateGrammar(BaseTestCreateGrammar, unittest.TestCase):
             "`expirated_at` TIMESTAMP"
             ")"
         )
+
+    def rename_table(self):
+        """
+            to_sql = self.schema.rename("users", "core", query_only=True)
+        """
+
+        return "RENAME TABLE `users` TO `core`"


### PR DESCRIPTION
`schema.rename('current_name', 'new_name')`

fix #62