### PR TITLE
refactored global scopes & added updated_at and created_at global scopes

### DIFF
--- a/src/masonite/orm/builder/QueryBuilder.py
+++ b/src/masonite/orm/builder/QueryBuilder.py
@@ -90,6 +90,7 @@ class QueryBuilder:
         table="",
         connection_details={},
         scopes={},
+        global_scopes={},
         owner=None,
     ):
         """QueryBuilder initializer
@@ -107,7 +108,7 @@ class QueryBuilder:
         self.connection = connection
         self.connection_details = connection_details
         self._scopes = {}
-        self._global_scopes = {}
+        self._global_scopes = global_scopes
         if scopes:
             self._scopes.update(scopes)
         self.boot()
@@ -125,7 +126,6 @@ class QueryBuilder:
 
     def __getattr__(self, attribute):
         if attribute in self._scopes:
-            # print('calling', attribute, 'on', cls)
             return getattr(self._scopes[attribute], attribute)
             # return cls
 
@@ -135,6 +135,7 @@ class QueryBuilder:
 
     def boot(self):
         self._columns = ()
+        self._creates = {}
 
         self._sql = ""
         self._sql_binding = ""
@@ -164,7 +165,7 @@ class QueryBuilder:
         return self
 
     def create(self, creates):
-        self._columns = creates
+        self._creates.update(creates)
         self.set_action("insert")
         return self
 
@@ -288,7 +289,6 @@ class QueryBuilder:
         return self
 
     def update(self, updates, dry=False):
-        print("update method???", updates)
         self._updates = (UpdateQueryExpression(updates),)
         self.set_action("update")
         if dry:
@@ -362,8 +362,11 @@ class QueryBuilder:
         return self
 
     def get_grammar(self):
+        """Either _creates when creating, otherwise use columns
+        """
+        columns = self._creates or self._columns
         return self.grammar(
-            columns=self._columns,
+            columns=columns,
             table=self.table,
             wheres=self._wheres,
             limit=self._limit,
@@ -380,10 +383,17 @@ class QueryBuilder:
         )
 
     def to_sql(self):
-        grammar = self.get_grammar()
 
         if not self._action:
             self.set_action("select")
+
+        for scope in self._global_scopes.get(self._action, []):
+            if not scope:
+                continue
+
+            scope(self.owner, self)
+
+        grammar = self.get_grammar()
 
         sql = getattr(
             grammar, "_compile_{action}".format(action=self._action)

--- a/src/masonite/orm/grammar/mysql_grammar.py
+++ b/src/masonite/orm/grammar/mysql_grammar.py
@@ -228,7 +228,7 @@ class MySQLGrammar(BaseGrammar):
         return "{keyword} {column} IS NULL"
 
     def where_not_null_string(self):
-        return "{keyword} {column} IS NOT NULL"
+        return " {keyword} {column} IS NOT NULL"
 
     def after_column_string(self):
         return "AFTER {after}"

--- a/src/masonite/orm/models/Model.py
+++ b/src/masonite/orm/models/Model.py
@@ -27,6 +27,12 @@ class Model:
     _booted = False
     __primary_key__ = "id"
     __casts__ = {}
+    _global_scopes = {
+        "select": [],
+        "insert": [],
+        "update": [],
+        "delete": [],
+    }
 
     __cast_map__ = {
         "bool": BoolCast,
@@ -54,10 +60,10 @@ class Model:
                 cls.__resolved_connection__,
                 table=cls.get_table_name(),
                 owner=cls,
+                global_scopes=cls._global_scopes,
             )
             cls.builder.set_action("select")
             cls._booted = True
-            cls._boot_parent_scopes(cls)
             cast_methods = [v for k, v in cls.__dict__.items() if k.startswith("get_")]
             for cast in cast_methods:
                 cls.__casts__[cast.__name__.replace("get_", "")] = cast
@@ -77,7 +83,8 @@ class Model:
             v for k, v in scope_class.__dict__.items() if k.startswith("boot_")
         ]
         for method in boot_methods:
-            method(cls, cls.builder)
+            for action in ["select", "insert", "update", "delete"]:
+                cls._global_scopes[action].append(method().get(action, []))
 
         return cls
 
@@ -141,8 +148,10 @@ class Model:
     def fill(self):
         pass
 
-    def create(self):
-        pass
+    @classmethod
+    def create(cls, dictionary):
+        to_sql = cls.builder.create(dictionary).to_sql()
+        return to_sql
 
     def delete(self):
         pass

--- a/tests/grammar/mysql/scopes/test_can_use_scopes.py
+++ b/tests/grammar/mysql/scopes/test_can_use_scopes.py
@@ -7,8 +7,31 @@ from src.masonite.orm.mixins.scope import scope
 
 
 class SoftDeletes:
-    def boot_soft_delete(self, query):
-        query.where_not_null("deleted_at")
+    def boot_soft_delete():
+        return {
+            "select": SoftDeletes.query_where_null,
+        }
+
+    def query_where_null(owner_cls, query):
+        return query.where_not_null("deleted_at")
+
+
+class TimeStamps:
+    def boot_timestamps():
+        return {
+            "update": TimeStamps.set_timestamp,
+            "insert": TimeStamps.set_timestamp_create,
+        }
+
+    def set_timestamp(owner_cls, query):
+        owner_cls.updated_at = "now"
+
+    def set_timestamp_create(owner_cls, query):
+        print("set timestamp create", owner_cls)
+        owner_cls.builder.create(
+            {"updated_at": "now", "created_at": "now",}
+        )
+        print("other builder??", owner_cls.builder, query)
 
 
 class User(Model):
@@ -38,8 +61,18 @@ class TestMySQLScopes(unittest.TestCase):
         sql = "SELECT * FROM `users` WHERE `active` = '2' AND `gender` = 'W' AND `name` = 'joe'"
         self.assertEqual(sql, User.active(2).gender("W").where("name", "joe").to_sql())
 
-    def test_can_use_global_scopes(self):
-        sql = "SELECT * FROM `users` WHERE `deleted_at` IS NOT NULL AND `name` = 'joe'"
+    def test_can_use_global_scopes_on_select(self):
+        sql = "SELECT * FROM `users` WHERE `name` = 'joe' AND `deleted_at` IS NOT NULL"
         self.assertEqual(
             sql, User.apply_scope(SoftDeletes).where("name", "joe").to_sql()
         )
+
+    def test_can_use_global_scopes_on_select(self):
+        sql = "SELECT * FROM `users` WHERE `name` = 'joe' AND `deleted_at` IS NOT NULL"
+        self.assertEqual(
+            sql, User.apply_scope(SoftDeletes).where("name", "joe").to_sql()
+        )
+
+    def test_can_use_global_scopes_on_time(self):
+        sql = "INSERT INTO `users` (`name`, `updated_at`, `created_at`) VALUES ('Joe', 'now', 'now')"
+        self.assertEqual(sql, User.apply_scope(TimeStamps).create({"name": "Joe"}))


### PR DESCRIPTION
Refactored how global scopes are written. This gives the ability to easily specify what action your global scope should apply to.

For example, a scope for `updated_at` and `created_at` should only be used for inserts and updates. On inserts we should specify the `updated_at` AND `created_at` but on updates we need to only specify the `updated_at` field.