### PR TITLE
Refactor compile table statements

### DIFF
--- a/src/masonite/orm/grammar/BaseGrammar.py
+++ b/src/masonite/orm/grammar/BaseGrammar.py
@@ -544,7 +544,8 @@ class BaseGrammar:
 
     def _compile_exists(self):
         return self.column_exists_string().format(
-            table=self._compile_table(self.table), value=self._compile_value(self._column)
+            table=self._compile_table(self.table),
+            value=self._compile_value(self._column),
         )
 
     def to_sql(self):

--- a/src/masonite/orm/grammar/BaseGrammar.py
+++ b/src/masonite/orm/grammar/BaseGrammar.py
@@ -65,7 +65,7 @@ class BaseGrammar:
 
     def _compile_create(self):
         self._sql = self.create_format().format(
-            table=self._compile_from(),
+            table=self._compile_table(self.table),
             columns=self._compile_create_columns(),
             constraints=self._compile_create_constraints().rstrip(" "),
             foreign_keys=self._compile_foreign_keys().rstrip(" "),
@@ -73,9 +73,9 @@ class BaseGrammar:
         return self
 
     def _compile_alter(self):
-        # sql = self.alter_start().format(table=self._compile_from())
+        # sql = self.alter_start().format(table=self._compile_table(self.table))
         self._sql = self.alter_format().format(
-            table=self._compile_from(),
+            table=self._compile_table(self.table),
             columns=self._compile_alter_columns(),
             constraints=self._compile_alter_constraints(),
             foreign_keys=self._compile_alter_foreign_keys(),
@@ -218,7 +218,7 @@ class BaseGrammar:
             self.select_format()
             .format(
                 columns=self._compile_columns(seperator=", "),
-                table=self._compile_from(),
+                table=self._compile_table(self.table),
                 wheres=self._compile_wheres(qmark=qmark),
                 limit=self._compile_limit(),
                 offset=self._compile_offset(),
@@ -236,7 +236,7 @@ class BaseGrammar:
     def _compile_update(self, qmark=False):
         self._sql = self.update_format().format(
             key_equals=self._compile_key_value_equals(qmark=qmark),
-            table=self._compile_from(),
+            table=self._compile_table(self.table),
             wheres=self._compile_wheres(qmark=qmark),
         )
 
@@ -263,7 +263,7 @@ class BaseGrammar:
     def _compile_insert(self):
         self._sql = self.insert_format().format(
             key_equals=self._compile_key_value_equals(),
-            table=self._compile_from(),
+            table=self._compile_table(self.table),
             columns=self._compile_columns(seperator=", "),
             values=self._compile_values(seperator=", "),
         )
@@ -273,7 +273,7 @@ class BaseGrammar:
     def _compile_delete(self):
         self._sql = self.delete_format().format(
             key_equals=self._compile_key_value_equals(),
-            table=self._compile_from(),
+            table=self._compile_table(self.table),
             wheres=self._compile_wheres(),
         )
 
@@ -352,13 +352,6 @@ class BaseGrammar:
 
     def _compile_alias(self, column):
         return column
-
-    def _compile_from(self):
-        return self.table_string().format(
-            table=self.table,
-            database=self._connection_details.get("database", ""),
-            prefix=self._connection_details.get("prefix", ""),
-        )
 
     def _compile_table(self, table):
         return self.table_string().format(
@@ -446,14 +439,14 @@ class BaseGrammar:
                 sql_string = self.between_string().format(
                     low=self._compile_value(where.low),
                     high=self._compile_value(where.high),
-                    column=self._compile_table(where.column),
+                    column=self._compile_column(where.column),
                     keyword=keyword,
                 )
             elif equality == "NOT BETWEEN":
                 sql_string = self.not_between_string().format(
                     low=self._compile_value(where.low),
                     high=self._compile_value(where.high),
-                    column=self._compile_table(where.column),
+                    column=self._compile_column(where.column),
                     keyword=keyword,
                 )
             elif value is None:
@@ -551,7 +544,7 @@ class BaseGrammar:
 
     def _compile_exists(self):
         return self.column_exists_string().format(
-            table=self._compile_from(), value=self._compile_value(self._column)
+            table=self._compile_table(self.table), value=self._compile_value(self._column)
         )
 
     def to_sql(self):


### PR DESCRIPTION
- Drop **_compile_from** method in replacement to **_compile_table(self, table)**
    - Motivation: repeated lines

- Replacement some statements from **_compile_column** to **_compile_table** when was being formatted a table and vice-versa ( **compile_table** to **compile_column** when formatting a column )