### PR TITLE
Implement new accessor naming convention

### DIFF
--- a/src/masonite/orm/connections/SQLiteConnection.py
+++ b/src/masonite/orm/connections/SQLiteConnection.py
@@ -92,4 +92,3 @@ class SQLiteConnection(BaseConnection):
             if self.__class__._connection and self.__class__._connection.isolation_level:
                 self.rollback()
             raise e
-

--- a/src/masonite/orm/models/Model.py
+++ b/src/masonite/orm/models/Model.py
@@ -108,7 +108,7 @@ class Model:
             }
 
             cls._loads = ()
-        
+
         return cls
 
     def _boot_parent_scopes(cls):
@@ -441,8 +441,11 @@ class Model:
         pass
 
     def __getattr__(self, attribute):
-        if ("get_" + attribute) in self.__class__.__dict__:
-            return self.__class__.__dict__.get(("get_" + attribute))(self)
+
+        new_name_accessor = "get_" + attribute + "_attribute"
+
+        if (new_name_accessor) in self.__class__.__dict__:
+            return self.__class__.__dict__.get(new_name_accessor)(self)
 
         if (
             "__attributes__" in self.__dict__

--- a/tests/mysql/model/test_accessors_and_mutators.py
+++ b/tests/mysql/model/test_accessors_and_mutators.py
@@ -15,7 +15,7 @@ class User(Model):
 
     __casts__ = {"is_admin": "bool"}
 
-    def get_name(self):
+    def get_name_attribute(self):
         return f"Hello, {self.get_raw_attribute('name')}"
 
     def set_name_attribute(self, attribute):


### PR DESCRIPTION
Changing convention of naming accessor attribute. From get_[attribute] to get_[attribute]_attribute.
Closes #121 