### PR TITLE
added connection resolver class

### DIFF
--- a/cc.py
+++ b/cc.py
@@ -1,11 +1,10 @@
 from src.masoniteorm.query import QueryBuilder
 from src.masoniteorm.connections import MySQLConnection, PostgresConnection
 from src.masoniteorm.query.grammars import MySQLGrammar, PostgresGrammar
-from config.database import DATABASES
 from src.masoniteorm.models import Model
 
 
-builder = QueryBuilder(connection=PostgresConnection, grammar=PostgresGrammar, connection_details=DATABASES).table("users").on("postgres")
+builder = QueryBuilder(connection=PostgresConnection, grammar=PostgresGrammar).table("users").on("postgres")
 
 
 
@@ -15,7 +14,7 @@ class User(Model):
     __connection__ = "sqlite"
     __table__ = "users"
 
-# user = User.create({"name": "phill", "email": "phill"})
+user = User.create({"name": "phill", "email": "phill"})
 print(User.get().count())
 
 print(user.serialize())

--- a/config/database.py
+++ b/config/database.py
@@ -3,6 +3,7 @@
 import os
 
 from src.masoniteorm.query import QueryBuilder
+from src.masoniteorm.connections import ConnectionResolver
 
 """
 |--------------------------------------------------------------------------
@@ -50,6 +51,8 @@ DATABASES = {
         'prefix': ''
     }
 }
+
+ConnectionResolver.set_connection_details(DATABASES)
 
 # DB = QueryBuilder(connection_details=DATABASES)
 

--- a/src/masoniteorm/connections/ConnectionFactory.py
+++ b/src/masoniteorm/connections/ConnectionFactory.py
@@ -1,7 +1,4 @@
-try:
-    from config.database import DATABASES
-except ImportError:
-    pass
+from .ConnectionResolver import ConnectionResolver
 
 from .MySQLConnection import MySQLConnection
 from .SQLiteConnection import SQLiteConnection
@@ -45,15 +42,15 @@ class ConnectionFactory:
         Returns:
             masonite.orm.connection.BaseConnection -- Returns an instance of a BaseConnection class.
         """
-        from config.database import DATABASES
 
+        connections = ConnectionResolver.get_connection_details()
         if key == "default":
-            connection_details = DATABASES.get(DATABASES.get("default"))
+            connection_details = connections.get(connections.get("default"))
             connection = self._connections.get(connection_details.get("driver"))
             connection.set_connection_settings(connection_details)
         else:
             connection = self._connections.get(key)
-            connection.set_connection_settings(DATABASES.get(key))
+            connection.set_connection_settings(connections.get(key))
 
         if connection:
             return connection

--- a/src/masoniteorm/connections/ConnectionResolver.py
+++ b/src/masoniteorm/connections/ConnectionResolver.py
@@ -1,0 +1,11 @@
+class ConnectionResolver:
+
+    _connection_details = {}
+
+    @classmethod
+    def set_connection_details(cls, connection_details):
+        cls._connection_details = connection_details
+
+    @classmethod
+    def get_connection_details(cls):
+        return cls._connection_details

--- a/src/masoniteorm/connections/__init__.py
+++ b/src/masoniteorm/connections/__init__.py
@@ -1,3 +1,4 @@
+from .ConnectionResolver import ConnectionResolver
 from .ConnectionFactory import ConnectionFactory
 from .MySQLConnection import MySQLConnection
 from .SQLiteConnection import SQLiteConnection

--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -13,7 +13,7 @@ from inflection import camelize
 
 from ..models.MigrationModel import MigrationModel
 from ..schema import Schema
-from ..connections import ConnectionFactory
+from ..connections import ConnectionFactory, ConnectionResolver
 from ..schema.grammars import GrammarFactory
 
 
@@ -27,7 +27,7 @@ class Migration:
     ):
         connection_class = ConnectionFactory().make(connection)
         grammar = GrammarFactory().make(connection)
-        from config.database import DATABASES
+        DATABASES = ConnectionResolver.get_connection_details()
 
         driver = DATABASES.get("default")
         self.schema = Schema(

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -6,7 +6,7 @@ import inspect
 
 from ..query import QueryBuilder
 from ..collection import Collection
-from ..connections import ConnectionFactory
+from ..connections import ConnectionFactory, ConnectionResolver
 from ..query.grammars import MySQLGrammar
 from ..scopes import BaseScope, SoftDeleteScope, SoftDeletesMixin, TimeStampsMixin
 
@@ -161,9 +161,7 @@ class Model(TimeStampsMixin, metaclass=ModelMeta):
         return self.builder
 
     def get_connection_details(self):
-        from config.database import DATABASES
-
-        return DATABASES
+        return ConnectionResolver.get_connection_details()
 
     def boot(self):
         if not self._booted:

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -18,6 +18,8 @@ from ..schema import Schema
 
 from .processors import PostProcessorFactory
 
+from ..connections import ConnectionResolver
+
 
 class QueryBuilder:
     """A builder class to manage the building and creation of query expressions."""
@@ -81,6 +83,9 @@ class QueryBuilder:
         self._offset = False
         self._model = model
         self.set_action("select")
+
+        if not self._connection_details:
+            self._connection_details = ConnectionResolver.get_connection_details()
 
         if self._connection_details and (
             not self._connection_driver or self._connection_driver == "default"

--- a/src/masoniteorm/schema/grammars/GrammarFactory.py
+++ b/src/masoniteorm/schema/grammars/GrammarFactory.py
@@ -1,6 +1,7 @@
 from .SQLiteGrammar import SQLiteGrammar
 from .MySQLGrammar import MySQLGrammar
 from .PostgresGrammar import PostgresGrammar
+from ...connections import ConnectionResolver
 
 
 class GrammarFactory:
@@ -24,9 +25,8 @@ class GrammarFactory:
         Returns:
             self
         """
-        from config.database import DATABASES
 
         if key == "default":
-            key = DATABASES.get(key)
+            key = ConnectionResolver.get_connection_details().get(key)
 
         return GrammarFactory.grammars.get(key)

--- a/tests/mysql/builder/test_mysql_builder_transaction.py
+++ b/tests/mysql/builder/test_mysql_builder_transaction.py
@@ -8,7 +8,6 @@ from src.masoniteorm.connections import ConnectionFactory
 from src.masoniteorm.relationships import belongs_to
 from src.masoniteorm.models import Model
 from tests.utils import MockConnectionFactory
-from config.database import DATABASES
 
 if os.getenv("RUN_MYSQL_DATABASE") == "True":
 
@@ -26,8 +25,6 @@ if os.getenv("RUN_MYSQL_DATABASE") == "True":
                 grammar=MySQLGrammar,
                 connection=connection,
                 table=table,
-                # model=User,
-                connection_details=DATABASES,
             ).on("mysql")
 
         def test_transaction(self):

--- a/tests/mysql/builder/test_query_builder_scopes.py
+++ b/tests/mysql/builder/test_query_builder_scopes.py
@@ -6,6 +6,7 @@ from src.masoniteorm.query.grammars import MySQLGrammar
 from src.masoniteorm.models import Model
 from src.masoniteorm.relationships import has_many
 from tests.utils import MockConnectionFactory
+from config.database import DATABASES
 from src.masoniteorm.scopes import SoftDeleteScope
 
 

--- a/tests/mysql/builder/test_query_builder_scopes.py
+++ b/tests/mysql/builder/test_query_builder_scopes.py
@@ -6,7 +6,6 @@ from src.masoniteorm.query.grammars import MySQLGrammar
 from src.masoniteorm.models import Model
 from src.masoniteorm.relationships import has_many
 from tests.utils import MockConnectionFactory
-from config.database import DATABASES
 from src.masoniteorm.scopes import SoftDeleteScope
 
 
@@ -19,7 +18,6 @@ class BaseTestQueryBuilderScopes(unittest.TestCase):
             grammar=MySQLGrammar,
             connection=connection,
             table=table,
-            model=None,
             connection_details=DATABASES,
         )
 

--- a/tests/sqlite/builder/test_sqlite_builder_insert.py
+++ b/tests/sqlite/builder/test_sqlite_builder_insert.py
@@ -27,7 +27,7 @@ class BaseTestQueryRelationships(unittest.TestCase):
             connection=connection,
             table=table,
             # model=User,
-            connection_details=DATABASES,
+            connection_details={},
         ).on("sqlite")
 
     def test_insert(self):


### PR DESCRIPTION
Adds a connection resolver class. This class will be used to "resolve" (or find) the connection settings. This class will need to be called sometime before connections start.

for Masonite we can likely just throw this in a service provider.

For your own projects outside of Masonite we can throw this inside a settings class or wherever you want to store the connections dictionary.