### PR TITLE
added pagination

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -99,6 +99,8 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         "order_by",
         "select",
         "set_global_scope",
+        "simple_paginate",
+        "paginate",
         "where_has",
         "chunk",
         "where_in",

--- a/src/masoniteorm/pagination/BasePaginator.py
+++ b/src/masoniteorm/pagination/BasePaginator.py
@@ -1,0 +1,10 @@
+import json
+
+
+class BasePaginator:
+    def __iter__(self):
+        for result in self.result:
+            yield result
+
+    def to_json(self):
+        return json.dumps(self.serialize())

--- a/src/masoniteorm/pagination/LengthAwarePaginator.py
+++ b/src/masoniteorm/pagination/LengthAwarePaginator.py
@@ -1,7 +1,8 @@
 import math
+from .BasePaginator import BasePaginator
 
 
-class LengthAwarePaginator:
+class LengthAwarePaginator(BasePaginator):
     def __init__(self, result, per_page, current_page, total, url=None):
         self.result = result
         self.current_page = current_page

--- a/src/masoniteorm/pagination/LengthAwarePaginator.py
+++ b/src/masoniteorm/pagination/LengthAwarePaginator.py
@@ -1,0 +1,30 @@
+import math
+
+
+class LengthAwarePaginator:
+    def __init__(self, result, per_page, current_page, total, url=None):
+        self.result = result
+        self.current_page = current_page
+        self.per_page = per_page
+        self.count = len(self.result)
+        self.last_page = int(math.ceil(total / per_page))
+        self.next_page = (int(self.current_page) + 1) if self.has_more_pages() else None
+        self.previous_page = (int(self.current_page) - 1) or None
+        self.total = total
+        self.url = url
+
+    def serialize(self):
+        return {
+            "data": self.result.serialize(),
+            "meta": {
+                "total": self.total,
+                "next_page": self.next_page,
+                "count": self.count,
+                "previous_page": self.previous_page,
+                "last_page": self.last_page,
+                "current_page": self.current_page,
+            },
+        }
+
+    def has_more_pages(self):
+        return self.current_page < self.last_page

--- a/src/masoniteorm/pagination/SimplePaginator.py
+++ b/src/masoniteorm/pagination/SimplePaginator.py
@@ -1,0 +1,24 @@
+class SimplePaginator:
+    def __init__(self, result, per_page, current_page, url=None):
+        self.result = result
+        self.current_page = current_page
+        self.per_page = per_page
+        self.count = len(self.result)
+        self.next_page = (int(self.current_page) + 1) if self.has_more_pages() else None
+        self.previous_page = (int(self.current_page) - 1) or None
+        self.url = url
+
+    def serialize(self):
+        return {
+            "data": self.result.serialize(),
+            "meta": {
+                "next_page": self.next_page,
+                "count": self.count,
+                "previous_page": self.previous_page,
+                "current_page": self.current_page,
+            },
+        }
+
+    def has_more_pages(self):
+        print("more?", len(self.result), self.per_page)
+        return len(self.result) > self.per_page

--- a/src/masoniteorm/pagination/SimplePaginator.py
+++ b/src/masoniteorm/pagination/SimplePaginator.py
@@ -1,4 +1,7 @@
-class SimplePaginator:
+from .BasePaginator import BasePaginator
+
+
+class SimplePaginator(BasePaginator):
     def __init__(self, result, per_page, current_page, url=None):
         self.result = result
         self.current_page = current_page

--- a/src/masoniteorm/pagination/__init__.py
+++ b/src/masoniteorm/pagination/__init__.py
@@ -1,0 +1,2 @@
+from .LengthAwarePaginator import LengthAwarePaginator
+from .SimplePaginator import SimplePaginator

--- a/tests/sqlite/builder/test_sqlite_builder_pagination.py
+++ b/tests/sqlite/builder/test_sqlite_builder_pagination.py
@@ -1,0 +1,58 @@
+import inspect
+import unittest
+
+from config.database import DATABASES
+from src.masoniteorm.connections import ConnectionFactory
+from src.masoniteorm.models import Model
+from src.masoniteorm.query import QueryBuilder
+from src.masoniteorm.query.grammars import SQLiteGrammar
+from src.masoniteorm.relationships import belongs_to
+from tests.utils import MockConnectionFactory
+
+
+class User(Model):
+    __connection__ = "sqlite"
+
+
+class BaseTestQueryRelationships(unittest.TestCase):
+
+    maxDiff = None
+
+    def get_builder(self, table="users", model=User):
+        connection = ConnectionFactory().make("sqlite")
+        return QueryBuilder(
+            grammar=SQLiteGrammar,
+            connection=connection,
+            table=table,
+            model=model,
+            connection_details=DATABASES,
+        ).on("sqlite")
+
+    def test_pagination(self):
+        builder = self.get_builder()
+
+        paginator = builder.table("users").paginate(1)
+
+        self.assertTrue(paginator.count)
+        self.assertTrue(paginator.serialize()["data"])
+        self.assertTrue(paginator.serialize()["meta"])
+        self.assertTrue(paginator.result)
+        self.assertTrue(paginator.current_page)
+        self.assertTrue(paginator.per_page)
+        self.assertTrue(paginator.count)
+        self.assertTrue(paginator.last_page)
+        self.assertTrue(paginator.next_page)
+        self.assertEqual(paginator.previous_page, None)
+        self.assertTrue(paginator.total)
+
+        paginator = builder.table("users").simple_paginate(10, 1)
+
+        self.assertTrue(paginator.count)
+        self.assertTrue(paginator.serialize()["data"])
+        self.assertTrue(paginator.serialize()["meta"])
+        self.assertTrue(paginator.result)
+        self.assertTrue(paginator.current_page)
+        self.assertTrue(paginator.per_page)
+        self.assertTrue(paginator.count)
+        self.assertEqual(paginator.next_page, None)
+        self.assertEqual(paginator.previous_page, None)

--- a/tests/sqlite/builder/test_sqlite_builder_pagination.py
+++ b/tests/sqlite/builder/test_sqlite_builder_pagination.py
@@ -44,8 +44,12 @@ class BaseTestQueryRelationships(unittest.TestCase):
         self.assertTrue(paginator.next_page)
         self.assertEqual(paginator.previous_page, None)
         self.assertTrue(paginator.total)
+        for user in paginator:
+            self.assertIsInstance(user, User)
 
         paginator = builder.table("users").simple_paginate(10, 1)
+
+        self.assertIsInstance(paginator.to_json(), str)
 
         self.assertTrue(paginator.count)
         self.assertTrue(paginator.serialize()["data"])
@@ -56,3 +60,7 @@ class BaseTestQueryRelationships(unittest.TestCase):
         self.assertTrue(paginator.count)
         self.assertEqual(paginator.next_page, None)
         self.assertEqual(paginator.previous_page, None)
+        for user in paginator:
+            self.assertIsInstance(user, User)
+
+        self.assertIsInstance(paginator.to_json(), str)


### PR DESCRIPTION
This PR adds pagination.

We can do something like this now:

```python
User.paginate(10, page=2)
```

This will return a LengthAwarePaginator class that will offset and limit the results to the offset based on the page. If you serialize this class it will serialize down to something like:

```python
{
    "data": [
        {
           "id": 1,
           ...
        }
    ],
    "meta": {
        "current_page": 1,
        "total": 156,
        ...
    }
}
```

- [x] Documentation
- [x] Links
- [x] Be able to iterate over the pagination class (which would just iterate over the self.result)

To officially close out #153 we need to add a `links()` method to the pagination class that will render some HTML for pagination buttons. I'm not really sure how to handle this. Do we just use simple buttons? I guess you would have to style it based on your CSS framework ..