### PR TITLE
Adds change support to the schema builder

### DIFF
--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -569,6 +569,10 @@ class Blueprint:
 
         return self
 
+    def change(self):
+        self.table.change_column(self._last_column)
+        return self
+
     def drop_unique(self, index):
         """Drops a unique index.
 

--- a/src/masoniteorm/schema/TableDiff.py
+++ b/src/masoniteorm/schema/TableDiff.py
@@ -13,6 +13,7 @@ class TableDiff(Table):
         self.removed_indexes = []
         self.added_indexes = {}
         self.added_columns = {}
+        self.changed_columns = {}
         self.dropped_columns = []
         self.dropped_foreign_keys = []
         self.renamed_columns = {}
@@ -65,3 +66,8 @@ class TableDiff(Table):
     def drop_foreign(self, name):
         self.dropped_foreign_keys.append(name)
         return self
+
+    def change_column(self, added_column):
+        self.added_columns.pop(added_column.name)
+
+        self.changed_columns.update({added_column.name: added_column})

--- a/src/masoniteorm/schema/platforms/MSSQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MSSQLPlatform.py
@@ -75,28 +75,39 @@ class MSSQLPlatform(Platform):
         if table.added_columns:
             add_columns = []
 
-            for name, column in table.get_added_columns().items():
-                if column.length:
-                    length = self.create_column_length(column.column_type).format(
-                        length=column.length
-                    )
-                else:
-                    length = ""
-                add_columns.append(
-                    self.add_column_string()
-                    .format(
-                        name=self.wrap_table(column.name),
-                        data_type=self.type_map.get(column.column_type, ""),
-                        length=length,
-                        constraint="PRIMARY KEY" if column.primary else "",
-                    )
-                    .strip()
-                )
+            # for name, column in table.get_added_columns().items():
+            #     if column.length:
+            #         length = self.create_column_length(column.column_type).format(
+            #             length=column.length
+            #         )
+            #     else:
+            #         length = ""
+            #     add_columns.append(
+            #         self.add_column_string()
+            #         .format(
+            #             name=self.wrap_table(column.name),
+            #             data_type=self.type_map.get(column.column_type, ""),
+            #             length=length,
+            #             constraint="PRIMARY KEY" if column.primary else "",
+            #         )
+            #         .strip()
+            #     )
 
             sql.append(
                 self.alter_format().format(
                     table=self.wrap_table(table.name),
-                    columns="ADD " + ", ".join(add_columns).strip(),
+                    columns="ADD "
+                    + ", ".join(self.columnize(table.added_columns)).strip(),
+                )
+            )
+
+        if table.changed_columns:
+            print("ss", self.columnize(table.changed_columns))
+            sql.append(
+                self.alter_format().format(
+                    table=self.wrap_table(table.name),
+                    columns="ALTER COLUMN "
+                    + ", ".join(self.columnize(table.changed_columns)).strip(),
                 )
             )
 

--- a/src/masoniteorm/schema/platforms/MSSQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MSSQLPlatform.py
@@ -73,26 +73,6 @@ class MSSQLPlatform(Platform):
         sql = []
 
         if table.added_columns:
-            add_columns = []
-
-            # for name, column in table.get_added_columns().items():
-            #     if column.length:
-            #         length = self.create_column_length(column.column_type).format(
-            #             length=column.length
-            #         )
-            #     else:
-            #         length = ""
-            #     add_columns.append(
-            #         self.add_column_string()
-            #         .format(
-            #             name=self.wrap_table(column.name),
-            #             data_type=self.type_map.get(column.column_type, ""),
-            #             length=length,
-            #             constraint="PRIMARY KEY" if column.primary else "",
-            #         )
-            #         .strip()
-            #     )
-
             sql.append(
                 self.alter_format().format(
                     table=self.wrap_table(table.name),
@@ -102,7 +82,6 @@ class MSSQLPlatform(Platform):
             )
 
         if table.changed_columns:
-            print("ss", self.columnize(table.changed_columns))
             sql.append(
                 self.alter_format().format(
                     table=self.wrap_table(table.name),
@@ -112,14 +91,7 @@ class MSSQLPlatform(Platform):
             )
 
         if table.renamed_columns:
-
             for name, column in table.get_renamed_columns().items():
-                if column.length:
-                    length = self.create_column_length(column.column_type).format(
-                        length=column.length
-                    )
-                else:
-                    length = ""
 
                 sql.append(
                     self.rename_column_string(table.name, name, column.name).strip()

--- a/src/masoniteorm/schema/platforms/MySQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MySQLPlatform.py
@@ -129,6 +129,16 @@ class MySQLPlatform(Platform):
                 )
             )
 
+        if table.changed_columns:
+
+            sql.append(
+                self.alter_format().format(
+                    table=self.wrap_table(table.name),
+                    columns="MODIFY "
+                    + ", ".join(self.columnize(table.changed_columns)),
+                )
+            )
+
         if table.dropped_columns:
             dropped_sql = []
 
@@ -186,6 +196,9 @@ class MySQLPlatform(Platform):
 
     def drop_column_string(self):
         return "DROP COLUMN {name}"
+
+    def change_column_string(self):
+        return "MODIFY {name}{data_type}{length} {nullable}{default} {constraint}"
 
     def rename_column_string(self):
         return "RENAME COLUMN {old} TO {to}"

--- a/src/masoniteorm/schema/platforms/Platform.py
+++ b/src/masoniteorm/schema/platforms/Platform.py
@@ -9,6 +9,8 @@ class Platform:
             else:
                 length = ""
 
+            print("ff", column.default)
+
             if column.default in (0,):
                 default = f" DEFAULT {column.default}"
             elif column.default in self.premapped_defaults:

--- a/src/masoniteorm/schema/platforms/SQLitePlatform.py
+++ b/src/masoniteorm/schema/platforms/SQLitePlatform.py
@@ -100,8 +100,7 @@ class SQLitePlatform(Platform):
 
             sql.append("DROP TABLE {table}".format(table=diff.name))
 
-            columns = original = diff.from_table.added_columns
-            print("ccc", diff.from_table.added_columns)
+            columns = diff.from_table.added_columns
 
             columns.update(diff.renamed_columns)
             columns.update(diff.changed_columns)


### PR DESCRIPTION
This adds the ability to change a column. This feature is tricky because some databases require you to get details of the previous columns data types to change the data type. 

We can do this by building out the `get_current_schema` methods of each platform class. Will need to be done on a per platform basis:

- [x] sqlite
- [x] mysql
- [x] postgres
- [x] mssql
