### PR TITLE
Add morphs helper to blueprint

### DIFF
--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -352,6 +352,26 @@ class Blueprint:
         )
         return self
 
+    def morphs(self, column, nullable=False):
+        """Sets a column to be used in a polymorphic relationship.
+
+        Arguments:
+            column {string} -- The column name.
+
+        Keyword Arguments:
+            nullable {bool} -- Whether the column is nullable. (default: {False})
+
+        Returns:
+            self
+        """
+        self._last_column = self.table.add_column(
+            "{}_id".format(column), "unsigned_integer", nullable=nullable
+        )
+        self._last_column = self.table.add_column(
+            "{}_type".format(column), "string", nullable=nullable
+        )
+        return self
+
     def to_sql(self):
         """Compiles the blueprint class into a sql statement.
 

--- a/tests/sqlite/schema/test_sqlite_schema_builder.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder.py
@@ -27,7 +27,7 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             blueprint.to_sql(), 'CREATE TABLE "users" (name VARCHAR(255), age INTEGER)'
         )
 
-    def test_can_add_columns_with_constaint(self):
+    def test_can_add_columns_with_constraint(self):
         with self.schema.create("users") as blueprint:
             blueprint.string("name")
             blueprint.integer("age")
@@ -39,7 +39,7 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             'CREATE TABLE "users" (name VARCHAR(255), age INTEGER, UNIQUE(name))',
         )
 
-    def test_can_add_columns_with_foreign_key_constaint(self):
+    def test_can_add_columns_with_foreign_key_constraint(self):
         with self.schema.create("users") as blueprint:
             blueprint.string("name").unique()
             blueprint.integer("age")
@@ -55,6 +55,18 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             "profile_id INTEGER, "
             "UNIQUE(name), "
             "CONSTRAINT users_profile_id_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
+        )
+
+    def test_can_use_morphs_for_polymorphism_relationships(self):
+        with self.schema.create("likes") as blueprint:
+            blueprint.morphs("record")
+
+        self.assertEqual(len(blueprint.table.added_columns), 2)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE "likes" '
+            "(record_id UNSIGNED INT, "
+            "record_type VARCHAR)"
         )
 
     def test_can_advanced_table_creation(self):


### PR DESCRIPTION
Added `morphs` to ease polymorphism relationships creation.
Still following Like,Article,Comment example we can now do:
```python
# likes migration
table.morphs("record")
```

- I did not setup an index automatically (between record_type and record_id) as done in Orator, should we do that ?
- I just created a test for proof, but what's the policy for testing "blueprints columns", they seems not tests except few, should I remove the test ? And should we do it for each connection ?