### PR TITLE
Fix docstrings of commands

### DIFF
--- a/src/masoniteorm/commands/MakeModelCommand.py
+++ b/src/masoniteorm/commands/MakeModelCommand.py
@@ -10,7 +10,7 @@ from ..migrations import Migration
 
 class MakeModelCommand(Command):
     """
-    Creates a new migration file.
+    Creates a new model file.
 
     model
         {name : The name of the model}

--- a/src/masoniteorm/commands/MigrateResetCommand.py
+++ b/src/masoniteorm/commands/MigrateResetCommand.py
@@ -4,7 +4,7 @@ from ..migrations import Migration
 
 class MigrateResetCommand(Command):
     """
-    Rolls back all migrations and migrates them again.
+    Rolls back all migrations.
 
     migrate:reset
         {--c|connection=default : The connection you want to run migrations on}

--- a/src/masoniteorm/commands/MigrateStatusCommand.py
+++ b/src/masoniteorm/commands/MigrateStatusCommand.py
@@ -5,7 +5,7 @@ from ..migrations import Migration
 
 class MigrateStatusCommand(Command):
     """
-    Run migrations.
+    Display migrations status.
 
     migrate:status
         {--c|connection=default : The connection you want to run migrations on}


### PR DESCRIPTION
@josephmancuso small fixes in masonite-orm command helps
```
AVAILABLE COMMANDS
  help                   Display the manual of a command
  migrate                Run migrations.
  migrate:refresh        Rolls back all migrations and migrates them again.
  migrate:reset          Rolls back all migrations.
  migrate:rollback       Rolls back the last batch of migrations.
  migrate:status         Display migrations status.
  migration              Creates a new migration file.
  model                  Creates a new model file.
  observer               Creates a new observer file.
  seed                   Creates a new seed file.
  seed:run               Run seeds.
```