### PR TITLE
Add last() to query builder

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -89,6 +89,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
     __passthrough__ = [
         "all",
         "first",
+        "last",
         "find_or_fail",
         "first_or_fail",
         "find_or_404",

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1007,18 +1007,18 @@ class QueryBuilder(ObservesEvents):
 
         return self.prepare_result(result)
 
-    def last(self, query=False):
+    def last(self, primary_key=None, query=False):
         """Gets the last record.
 
         Returns:
             dictionary -- Returns a dictionary of results.
         """
-
+        _primary_key = primary_key if primary_key else self._model.get_primary_key()
         if query:
-            return self.limit(1).order_by(self._model.get_primary_key(), direction="DESC")
+            return self.limit(1).order_by(_primary_key, direction="DESC")
 
         result = self.new_connection().query(
-            self.limit(1).order_by(self._model.get_primary_key(), direction="DESC").to_qmark(), self._bindings, results=1
+            self.limit(1).order_by(_primary_key, direction="DESC").to_qmark(), self._bindings, results=1
         )
 
         return self.prepare_result(result)

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1007,6 +1007,22 @@ class QueryBuilder(ObservesEvents):
 
         return self.prepare_result(result)
 
+    def last(self, query=False):
+        """Gets the last record.
+
+        Returns:
+            dictionary -- Returns a dictionary of results.
+        """
+
+        if query:
+            return self.limit(1).order_by(self._model.get_primary_key(), direction="DESC")
+
+        result = self.new_connection().query(
+            self.limit(1).order_by(self._model.get_primary_key(), direction="DESC").to_qmark(), self._bindings, results=1
+        )
+
+        return self.prepare_result(result)
+
     def _get_eager_load_result(self, related, collection):
         return related.eager_load_from_collection(collection)
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1007,18 +1007,19 @@ class QueryBuilder(ObservesEvents):
 
         return self.prepare_result(result)
 
-    def last(self, primary_key=None, query=False):
-        """Gets the last record.
+    def last(self, column=None, query=False):
+        """Gets the last record, ordered by column in descendant order or primary
+        key if no column is given.
 
         Returns:
             dictionary -- Returns a dictionary of results.
         """
-        _primary_key = primary_key if primary_key else self._model.get_primary_key()
+        _column = column if column else self._model.get_primary_key()
         if query:
-            return self.limit(1).order_by(_primary_key, direction="DESC")
+            return self.limit(1).order_by(_column, direction="DESC")
 
         result = self.new_connection().query(
-            self.limit(1).order_by(_primary_key, direction="DESC").to_qmark(), self._bindings, results=1
+            self.limit(1).order_by(_column, direction="DESC").to_qmark(), self._bindings, results=1
         )
 
         return self.prepare_result(result)

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -77,6 +77,13 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_last(self):
+        builder = self.get_builder().last(query=True)
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_first_or_fail_exception(self):
         with self.assertRaises(ModelNotFound):
             user = self.get_builder().where("name", "=", "Marlysson").first_or_fail()
@@ -408,6 +415,13 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.first()
         """
         return """SELECT * FROM "users" LIMIT 1"""
+
+    def last(self):
+        """
+        builder = self.get_builder()
+        builder.last()
+        """
+        return """SELECT * FROM "users" LIMIT 1 ORDER BY "users"."id" DESC"""
 
     def all(self):
         """

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -80,6 +80,9 @@ class BaseTestQueryBuilder:
     def test_last(self):
         UserMock.order_by("id", "DESC").first().id == UserMock.last("id").id
 
+    def test_last_with_default_primary_key(self):
+        UserMock.order_by("id", "DESC").first().id == UserMock.last().id
+
     def test_first_or_fail_exception(self):
         with self.assertRaises(ModelNotFound):
             user = self.get_builder().where("name", "=", "Marlysson").first_or_fail()

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -78,11 +78,7 @@ class BaseTestQueryBuilder:
         self.assertEqual(builder.to_sql(), sql)
 
     def test_last(self):
-        builder = self.get_builder().last(query=True)
-        sql = getattr(
-            self, inspect.currentframe().f_code.co_name.replace("test_", "")
-        )()
-        self.assertEqual(builder.to_sql(), sql)
+        UserMock.order_by("id", "DESC").first().id == UserMock.last("id").id
 
     def test_first_or_fail_exception(self):
         with self.assertRaises(ModelNotFound):
@@ -415,13 +411,6 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.first()
         """
         return """SELECT * FROM "users" LIMIT 1"""
-
-    def last(self):
-        """
-        builder = self.get_builder()
-        builder.last()
-        """
-        return """SELECT * FROM "users" LIMIT 1 ORDER BY "users"."id" DESC"""
 
     def all(self):
         """


### PR DESCRIPTION
Right now we can do:
* `first()` and `last()` on Collections:
```python
User.all().first()
User.all().last()
```
* `first()` on the Model (pass through the query builder actually)
```python
User.first() # User with id 1
```
* but no `last()`to get the last row of the table. 
```python
User.last()
```

One way could be to do this by ordering by the primary ket in descending order. But what about running query not related to models or when `_model` is not defined in the query builder ?

@josephmancuso @Marlysson what do you think about this ?