### PR TITLE
added ability to pass list to find method

### DIFF
--- a/src/masoniteorm/connections/SQLiteConnection.py
+++ b/src/masoniteorm/connections/SQLiteConnection.py
@@ -5,6 +5,7 @@ from ..schema.platforms import SQLitePlatform
 from ..query.processors import SQLitePostProcessor
 import logging
 from .ConnectionResolver import ConnectionResolver
+from ..exceptions import QueryException
 
 
 class SQLiteConnection(BaseConnection):

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -168,13 +168,13 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         )
         self.__resolved_connection__ = DB.connection_factory.make(connection_driver)
         self.builder = QueryBuilder(
-            grammar=self.__resolved_connection__.get_default_query_grammar(),
+            # grammar=self.__resolved_connection__.get_default_query_grammar(),
             connection=self.__connection__,
-            connection_class=self.__resolved_connection__,
+            # connection_class=self.__resolved_connection__,
             table=self.get_table_name(),
             connection_details=self.get_connection_details(),
             model=self,
-            connection_driver=connection_driver,
+            # connection_driver=connection_driver,
             scopes=self._scopes,
             dry=self.__dry__,
         )
@@ -208,7 +208,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         return cls.__table__ or tableize(cls.__name__)
 
     @classmethod
-    def find(cls, record_id):
+    def find(cls, record_id, query=False):
         """Finds a row by the primary key ID.
 
         Arguments:
@@ -217,8 +217,15 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         Returns:
             Model
         """
+        if isinstance(record_id, (list, tuple)):
+            builder = cls().where_in(cls.get_primary_key(), record_id)
+        else:
+            builder = cls().where(cls.get_primary_key(), record_id)
 
-        return cls().where(cls.get_primary_key(), record_id).first()
+        if query:
+            return builder.to_sql()
+        else:
+            return builder.get()
 
     def first_or_new(self):
         pass

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -97,9 +97,14 @@ class QueryBuilder(ObservesEvents):
             from config.database import DB
 
             self._connection_details = DB.get_connection_details()
+
         self.on(connection)
-        self.grammar = grammar
-        self.connection_class = connection_class
+
+        if grammar:
+            self.grammar = grammar
+
+        if connection_class:
+            self.connection_class = connection_class
 
     def reset(self):
         """Resets the query builder instance so you can make multiple calls with the same builder instance"""
@@ -627,6 +632,7 @@ class QueryBuilder(ObservesEvents):
                 (QueryExpression(column, "IN", SubSelectExpression(wheres))),
             )
         else:
+            print("wheres", wheres)
             wheres = [str(x) for x in wheres]
             self._wheres += ((QueryExpression(column, "IN", wheres)),)
         return self
@@ -1190,6 +1196,7 @@ class QueryBuilder(ObservesEvents):
     def new_connection(self):
         if self._connection:
             return self._connection
+
         self._connection = self.connection_class(
             **self.get_connection_information(), name=self.connection
         ).make_connection()

--- a/tests/sqlite/models/test_sqlite_model.py
+++ b/tests/sqlite/models/test_sqlite_model.py
@@ -33,3 +33,14 @@ class BaseTestQueryRelationships(unittest.TestCase):
         sql = User.update({"name": "joe"}).to_sql()
 
         self.assertEqual(sql, """UPDATE "users" SET "name" = 'joe'""")
+
+    def test_can_find_list(self):
+        sql = User.find(1, query=True)
+
+        self.assertEqual(sql, """SELECT * FROM "users" WHERE "users"."id" = '1'""")
+
+        sql = User.find([1, 2, 3], query=True)
+
+        self.assertEqual(
+            sql, """SELECT * FROM "users" WHERE "users"."id" IN ('1','2','3')"""
+        )


### PR DESCRIPTION
Closes #253 

This PR adds the ability to pass a list or tuple into the find method to get back a collection of records based on the primary key of the model:

```python
User.find([1,2,3])
```