### PR TITLE
added truncating with foreign keys disabled

### DIFF
--- a/src/masoniteorm/schema/Schema.py
+++ b/src/masoniteorm/schema/Schema.py
@@ -205,8 +205,8 @@ class Schema:
 
         return bool(self.new_connection().query(sql, ()))
 
-    def truncate(self, table):
-        sql = self.platform().compile_truncate(table)
+    def truncate(self, table, foreign_keys=False):
+        sql = self.platform().compile_truncate(table, foreign_keys=foreign_keys)
 
         if self._dry:
             self._sql = sql
@@ -224,6 +224,24 @@ class Schema:
         sql = self.platform().compile_table_exists(
             table, database=self.get_connection_information().get("database")
         )
+
+        if self._dry:
+            self._sql = sql
+            return sql
+
+        return bool(self.new_connection().query(sql, ()))
+
+    def enable_foreign_key_constraints(self):
+        sql = self.platform().enable_foreign_key_constraints()
+
+        if self._dry:
+            self._sql = sql
+            return sql
+
+        return bool(self.new_connection().query(sql, ()))
+
+    def disable_foreign_key_constraints(self):
+        sql = self.platform().disable_foreign_key_constraints()
 
         if self._dry:
             self._sql = sql

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -252,8 +252,15 @@ class PostgresPlatform(Platform):
     def compile_table_exists(self, table, database=None):
         return f"SELECT * from information_schema.tables where table_name='{table}'"
 
-    def compile_truncate(self, table):
-        return f"TRUNCATE {self.wrap_table(table)}"
+    def compile_truncate(self, table, foreign_keys=False):
+        if not foreign_keys:
+            return f"TRUNCATE {self.wrap_table(table)}"
+
+        return [
+            f"ALTER TABLE {self.wrap_table(table)} DISABLE TRIGGER ALL",
+            f"TRUNCATE {self.wrap_table(table)}",
+            f"ALTER TABLE {self.wrap_table(table)} ENABLE TRIGGER ALL",
+        ]
 
     def compile_rename_table(self, current_name, new_name):
         return f"ALTER TABLE {self.wrap_table(current_name)} RENAME TO {self.wrap_table(new_name)}"
@@ -286,3 +293,13 @@ class PostgresPlatform(Platform):
                 table.set_primary_key(column["column_name"])
 
         return table
+
+    def enable_foreign_key_constraints(self):
+        """Postgres does not allow a global way to enable foreign key constraints
+        """
+        return ""
+
+    def disable_foreign_key_constraints(self):
+        """Postgres does not allow a global way to disable foreign key constraints
+        """
+        return ""

--- a/tests/mssql/schema/test_mssql_schema_builder.py
+++ b/tests/mssql/schema/test_mssql_schema_builder.py
@@ -143,3 +143,25 @@ class TestMSSQLSchemaBuilder(unittest.TestCase):
             sql,
             "SELECT 1 FROM sys.columns WHERE Name = N'name' AND Object_ID = Object_ID(N'users')",
         )
+
+    def test_can_enable_foreign_keys(self):
+        sql = self.schema.enable_foreign_key_constraints()
+
+        self.assertEqual(sql, "")
+
+    def test_can_disable_foreign_keys(self):
+        sql = self.schema.disable_foreign_key_constraints()
+
+        self.assertEqual(sql, "")
+
+    def test_can_truncate_without_foreign_keys(self):
+        sql = self.schema.truncate("users", foreign_keys=True)
+
+        self.assertEqual(
+            sql,
+            [
+                "ALTER TABLE [users] NOCHECK CONSTRAINT ALL",
+                "TRUNCATE TABLE [users]",
+                "ALTER TABLE [users] WITH CHECK CHECK CONSTRAINT ALL",
+            ],
+        )

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -154,3 +154,25 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             sql,
             "SELECT column_name FROM information_schema.columns WHERE table_name='users' and column_name='name'",
         )
+
+    def test_can_enable_foreign_keys(self):
+        sql = self.schema.enable_foreign_key_constraints()
+
+        self.assertEqual(sql, "SET FOREIGN_KEY_CHECKS=1")
+
+    def test_can_disable_foreign_keys(self):
+        sql = self.schema.disable_foreign_key_constraints()
+
+        self.assertEqual(sql, "SET FOREIGN_KEY_CHECKS=0")
+
+    def test_can_truncate_without_foreign_keys(self):
+        sql = self.schema.truncate("users", foreign_keys=True)
+
+        self.assertEqual(
+            sql,
+            [
+                "SET FOREIGN_KEY_CHECKS=0",
+                "TRUNCATE `users`",
+                "SET FOREIGN_KEY_CHECKS=1",
+            ],
+        )

--- a/tests/postgres/schema/test_postgres_schema_builder.py
+++ b/tests/postgres/schema/test_postgres_schema_builder.py
@@ -150,3 +150,25 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
             table.to_sql(),
             'CREATE TABLE "users" (id CHAR(36) NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL, public_id CHAR(36) NULL)',
         )
+
+    def test_can_enable_foreign_keys(self):
+        sql = self.schema.enable_foreign_key_constraints()
+
+        self.assertEqual(sql, "")
+
+    def test_can_disable_foreign_keys(self):
+        sql = self.schema.disable_foreign_key_constraints()
+
+        self.assertEqual(sql, "")
+
+    def test_can_truncate_without_foreign_keys(self):
+        sql = self.schema.truncate("users", foreign_keys=True)
+
+        self.assertEqual(
+            sql,
+            [
+                'ALTER TABLE "users" DISABLE TRIGGER ALL',
+                'TRUNCATE "users"',
+                'ALTER TABLE "users" ENABLE TRIGGER ALL',
+            ],
+        )

--- a/tests/sqlite/schema/test_sqlite_schema_builder.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder.py
@@ -151,3 +151,25 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             sql,
             "SELECT column_name FROM information_schema.columns WHERE table_name='users' and column_name='name'",
         )
+
+    def test_can_enable_foreign_keys(self):
+        sql = self.schema.enable_foreign_key_constraints()
+
+        self.assertEqual(sql, "PRAGMA foreign_keys = ON")
+
+    def test_can_disable_foreign_keys(self):
+        sql = self.schema.disable_foreign_key_constraints()
+
+        self.assertEqual(sql, "PRAGMA foreign_keys = OFF")
+
+    def test_can_truncate_without_foreign_keys(self):
+        sql = self.schema.truncate("users", foreign_keys=True)
+
+        self.assertEqual(
+            sql,
+            [
+                "PRAGMA foreign_keys = OFF",
+                'TRUNCATE "users"',
+                "PRAGMA foreign_keys = ON",
+            ],
+        )


### PR DESCRIPTION
Closes #278 

Adds the ability to truncate a table without foreign key checks.

Typically if any records in a table reference another table then you will not be able to truncate the table but sometimes you just want to start over or reimport table data so its useful to get rid of the table even tho it will break all foreign keys in other tables.

To do this you can now do this:

```python
schema.truncate(foreign_keys=False)
```

The `foreign_keys` parameter is True by default if you don't pass it