### PR TITLE
Adds when to query builder

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -108,6 +108,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         "where_in",
         "where",
         "with_",
+        "when",
         "update",
     ]
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1388,3 +1388,8 @@ class QueryBuilder(ObservesEvents):
     def macro(self, name, callable):
         self._macros.update({name: callable})
         return self
+
+    def when(self, conditional, callback):
+        if conditional:
+            callback(self)
+        return self

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -668,3 +668,14 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.where("age", "like", "%name%")
         """
         return """SELECT * FROM "users" WHERE "users"."age" NOT LIKE '%name%'"""
+
+    def test_when(self):
+        builder = self.get_builder()
+        sql = builder.when(19 > 18, lambda q: q.where("age_restricted", 1)).to_sql()
+        return self.assertEqual(
+            sql, """SELECT * FROM "users" WHERE "users"."age_restricted" = '1'"""
+        )
+
+        builder = self.get_builder()
+        sql = builder.when(17 > 18, lambda q: q.where("age_restricted", 1)).to_sql()
+        return self.assertEqual(sql, """SELECT * FROM "users\"""")


### PR DESCRIPTION
Closes #277 

Adds the ability to use `when` in the query builder. We can use this to easily conditionally add query statements 

```python
age = 21

User.when(age >= 21, lambda q: q.where('age_restricted', 1)).get()
```

This will result in different queries based on the conditional in the first parameter. If the first parameter is truthy then run the second parameter