### PR TITLE
fixed soft deletes scope

### DIFF
--- a/src/masoniteorm/scopes/SoftDeleteScope.py
+++ b/src/masoniteorm/scopes/SoftDeleteScope.py
@@ -6,6 +6,7 @@ class SoftDeleteScope(BaseScope):
 
     def on_boot(self, builder):
         builder.set_global_scope("_where_null", self._where_null, action="select")
+        builder.set_global_scope("_query_set_null_on_delete", self._query_set_null_on_delete, action="delete")
         builder.macro("with_trashed", self._with_trashed)
 
     def on_remove(self, builder):
@@ -18,5 +19,5 @@ class SoftDeleteScope(BaseScope):
         builder.remove_global_scope("_where_null", action="select")
         return builder
 
-    # def query_set_null(self, builder):
-    #     return query.set_action("update").set_updates({"deleted_at": "now"})
+    def _query_set_null_on_delete(self, builder):
+        return builder.set_action("update").set_updates({"deleted_at": builder._model.get_new_date()})

--- a/tests/scopes/test_default_global_scopes.py
+++ b/tests/scopes/test_default_global_scopes.py
@@ -94,3 +94,10 @@ class TestTimeStampsScope(unittest.TestCase):
         self.scope.set_timestamp_create(self.builder)
         self.assertNotIn("created_at", self.builder._creates)
         self.assertNotIn("updated_at", self.builder._creates)
+
+    def test_soft_deletes_changes_delete_to_update(self):
+        UserSoft.__timestamps__ = False
+        user = UserSoft.hydrate({"id": 1})
+        sql = user.delete(query=True).to_sql()
+        self.assertTrue(sql.startswith("UPDATE"))
+        


### PR DESCRIPTION
Closes #281 

Fixes issue where deleting a model record with the SoftDeletesMixin was actually deleting the record rather than setting the deleted_at column