### PR TITLE
added dict param to where method

### DIFF
--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -465,6 +465,9 @@ class QueryBuilder(ObservesEvents):
             self._wheres += (
                 (QueryExpression(None, operator, SubGroupExpression(builder))),
             )
+        elif isinstance(column, dict):
+            for key, value in column.items():
+                self._wheres += ((QueryExpression(key, '=', value, "value")),)
         elif isinstance(value, QueryBuilder):
             self._wheres += (
                 (QueryExpression(column, operator, SubSelectExpression(value))),

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -161,6 +161,14 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_where_dictionary(self):
+        builder = self.get_builder()
+        builder.where({"name": "Joe"})
+        sql = getattr(
+            self, 'where'
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_where_exists(self):
         builder = self.get_builder()
         builder.where_exists("name")


### PR DESCRIPTION
Closes #293 

Adds the ability to specify a dict for the where clause:

```python
User.where({"name": "Joe"})
```