### PR TITLE
added after creating to factories

### DIFF
--- a/tests/factories/test_factories.py
+++ b/tests/factories/test_factories.py
@@ -10,16 +10,26 @@ class User(Model):
     pass
 
 
+class AfterCreatedModel(Model):
+    __dry__ = True
+    pass
+
+
 class TestFactories(unittest.TestCase):
     def setUp(self):
         factory.register(User, self.user_factory)
         factory.register(User, self.named_user_factory, name="admin")
+        factory.register(AfterCreatedModel, self.named_user_factory)
+        factory.after_creating(AfterCreatedModel, self.after_creating)
 
     def user_factory(self, faker):
         return {"id": 1, "name": faker.name()}
 
     def named_user_factory(self, faker):
         return {"id": 1, "name": faker.name(), "admin": 1}
+
+    def after_creating(self, model, faker):
+        model.after_created = True
 
     def test_can_make_single(self):
         user = factory(User).make({"id": 1, "name": "Joe"})
@@ -41,6 +51,18 @@ class TestFactories(unittest.TestCase):
         user = factory(User).make(name="admin")
         self.assertEqual(user.admin, 1)
 
-    # def test_can_create(self):
-    #     user = factory(User).create()
-    #     self.assertTrue(user.name)
+    def test_after_creates(self):
+        user = factory(AfterCreatedModel).create()
+        self.assertTrue(user.name)
+        self.assertEqual(user.after_created, True)
+
+        users = factory(AfterCreatedModel).create({"name": "billy"})
+        self.assertEqual(users.name, "billy")
+        self.assertEqual(users.after_created, True)
+
+        users = factory(AfterCreatedModel).make()
+        self.assertEqual(users.after_created, True)
+
+        users = factory(AfterCreatedModel, 2).make()
+        for user in users:
+            self.assertEqual(user.after_created, True)

--- a/tests/sqlite/relationships/test_sqlite_relationships.py
+++ b/tests/sqlite/relationships/test_sqlite_relationships.py
@@ -48,6 +48,7 @@ class User(Model):
     def get_is_admin(self):
         return "You are an admin"
 
+
 class UserHasOne(Model):
 
     __table__ = "users"
@@ -56,8 +57,8 @@ class UserHasOne(Model):
 
     @has_one("user_id", "user_id")
     def profile(self):
-        print('re')
         return Profile
+
 
 class TestRelationships(unittest.TestCase):
     maxDiff = None
@@ -92,10 +93,7 @@ class TestRelationships(unittest.TestCase):
             user
 
     def test_relationship_has_one_sql(self):
-        self.assertEqual(
-            UserHasOne.profile().to_sql(),
-            'SELECT * FROM "profiles"',
-        )
+        self.assertEqual(UserHasOne.profile().to_sql(), 'SELECT * FROM "profiles"')
 
     def test_loading_with_nested_with(self):
         users = User.with_("articles", "articles.logo").get()


### PR DESCRIPTION
Closes #252 

This PR adds the ability to add an `after_creating` method to the factory class.

You can now do something like this:

```python
def add_order(self, faker):
    return {
        "subtotal": faker.amount(),
        "tax": faker.amount(),
    }

def after_order(self, model, faker):
    model.grand_total = model.subtotal + model.tax

factory.register(User, add_order)
factory.after_creating(User, after_order)
```

Now the order model will be passed to this `after_order` callback when you create the order class:

```python
order = factory(Order).create()
order.grand_total #== now set because it was passed to the `after_order` method
```