### PR TITLE
fix decimal length

### DIFF
--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -253,8 +253,10 @@ class Blueprint:
             self
         """
         self._last_column = self.table.add_column(
-            column, "decimal", length="{length}, {precision}".format(length=length, precision=precision), 
-            nullable=nullable
+            column,
+            "decimal",
+            length="{length}, {precision}".format(length=length, precision=precision),
+            nullable=nullable,
         )
         return self
 

--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -315,6 +315,21 @@ class Blueprint:
         )
         return self
 
+    def json(self, column, nullable=False):
+        """Sets a column to be the json representation for the table.
+
+        Arguments:
+            column {string} -- The column name.
+
+        Keyword Arguments:
+            nullable {bool} -- Whether the column is nullable. (default: {False})
+
+        Returns:
+            self
+        """
+        self._last_column = self.table.add_column(column, "json", nullable=nullable)
+        return self
+
     def unsigned(self, column=None, length=None, nullable=False):
         """Sets a column to be the unsigned integer representation for the table.
 

--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -253,7 +253,8 @@ class Blueprint:
             self
         """
         self._last_column = self.table.add_column(
-            column, "decimal", length=(length, precision), nullable=nullable
+            column, "decimal", length="{length}, {precision}".format(length=length, precision=precision), 
+            nullable=nullable
         )
         return self
 

--- a/tests/sqlite/schema/test_sqlite_schema_builder.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder.py
@@ -95,6 +95,7 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             blueprint.string("name")
             blueprint.string("duration")
             blueprint.string("url")
+            blueprint.json("payload")
             blueprint.datetime("published_at")
             blueprint.string("thumbnail").nullable()
             blueprint.integer("premium")
@@ -105,12 +106,12 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             blueprint.text("description")
             blueprint.timestamps()
 
-        self.assertEqual(len(blueprint.table.added_columns), 11)
+        self.assertEqual(len(blueprint.table.added_columns), 12)
         self.assertEqual(
             blueprint.to_sql(),
             (
                 'CREATE TABLE "users" (id INTEGER PRIMARY KEY, name VARCHAR(255), duration VARCHAR(255), '
-                "url VARCHAR(255), published_at DATETIME, thumbnail VARCHAR(255), premium INTEGER, "
+                "url VARCHAR(255), payload JSON, published_at DATETIME, thumbnail VARCHAR(255), premium INTEGER, "
                 "author_id UNSIGNED INT, description TEXT, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
                 "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
                 "CONSTRAINT users_author_id_foreign FOREIGN KEY (author_id) REFERENCES users(id))"


### PR DESCRIPTION
table.decimal('credit', 12, 2) 

length should not be tuple, create_column_length format str already have parentheses `return "({length})"` 

if we pass a tuple , it will be DECIMAL((12, 2))

missing json type.