### PR TITLE
Improve random collection method

### DIFF
--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -275,12 +275,18 @@ class Collection:
         self[key] = value
         return self
 
-    def random(self):
+    def random(self, count=None):
         """Returns a random item of the collection."""
-        if self.count() == 0:
+        collection_count = self.count()
+        if collection_count == 0:
             return None
-        index = random.randint(0, self.count() - 1)
-        return self[index]
+        elif count and count > collection_count:
+            raise ValueError("count argument must be inferior to collection length.")
+        elif count:
+            self._items = random.sample(self._items, k=count)
+            return self
+        else:
+            return random.choice(self._items)
 
     def reduce(self, callback, initial=0):
         return reduce(callback, self, initial)

--- a/tests/collection/test_collection.py
+++ b/tests/collection/test_collection.py
@@ -578,3 +578,16 @@ class TestCollection(unittest.TestCase):
         collection = Collection([3])
         item = collection.random()
         self.assertEqual(item, 3)
+
+    def test_random_with_count(self):
+        collection = Collection([1, 2, 3, 4])
+        items = collection.random(2)
+        self.assertEqual(items.count(), 2)
+        self.assertIsInstance(items, Collection)
+
+        with self.assertRaises(ValueError):
+            items = collection.random(6)
+
+        items = collection.random(1)
+        self.assertEqual(items.count(), 1)
+        self.assertIsInstance(items, Collection)


### PR DESCRIPTION
I'll document this in the doc but quickly
```
users.random() # == one user instance
users.random(3) #== a collection of 3 users picked randomly
users.random(1) #== a collection of 1 user picked randomly
```
When every you give a count to random it will return a Collection (so it can be chained) else it will just return the element.
Edges cases are handled (count > collection length or empty collection)
