### PR TITLE
added multiple order by

### DIFF
--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -100,10 +100,15 @@ class OrderByExpression:
         self.column = column.strip()
 
         self.raw = raw
+        self.alias = None
 
         self.direction = direction
 
-        if " as " in self.column:
-            self.column, self.direction = self.column.split(" as ")
+        if raw is False:
+            if self.column.endswith(" desc"):
+                self.column = self.column.split(" desc")[0].strip()
+                self.direction = "DESC"
 
-        self.alias = None
+            if self.column.endswith(" asc"):
+                self.column = self.column.split(" asc")[0].strip()
+                self.direction = "ASC"

--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -91,3 +91,19 @@ class SelectExpression:
         self.raw = raw
         if raw is False and " as " in self.column:
             self.column, self.alias = self.column.split(" as ")
+
+
+class OrderByExpression:
+    """A helper class to manage select expressions."""
+
+    def __init__(self, column, direction="ASC", raw=False):
+        self.column = column.strip()
+
+        self.raw = raw
+
+        self.direction = direction
+
+        if " as " in self.column:
+            self.column, self.direction = self.column.split(" as ")
+
+        self.alias = None

--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -96,13 +96,14 @@ class SelectExpression:
 class OrderByExpression:
     """A helper class to manage select expressions."""
 
-    def __init__(self, column, direction="ASC", raw=False):
+    def __init__(self, column, direction="ASC", raw=False, bindings=()):
         self.column = column.strip()
 
         self.raw = raw
         self.alias = None
 
         self.direction = direction
+        self.bindings = bindings
 
         if raw is False:
             if self.column.endswith(" desc"):

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1056,7 +1056,7 @@ class QueryBuilder(ObservesEvents):
             self._order_by += (OrderByExpression(col, direction=direction),)
         return self
 
-    def order_by_raw(self, query):
+    def order_by_raw(self, query, bindings=()):
         """Specifies a column to order by.
 
         Arguments:
@@ -1068,7 +1068,7 @@ class QueryBuilder(ObservesEvents):
         Returns:
             self
         """
-        self._order_by += (OrderByExpression(query, raw=True),)
+        self._order_by += (OrderByExpression(query, raw=True, bindings=bindings),)
         return self
 
     def group_by(self, column):

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -7,6 +7,7 @@ from ..expressions.expressions import (
     SelectExpression,
     BetweenExpression,
     QueryExpression,
+    OrderByExpression,
     UpdateQueryExpression,
     JoinExpression,
     HavingExpression,
@@ -1051,8 +1052,23 @@ class QueryBuilder(ObservesEvents):
         Returns:
             self
         """
-        for col in column.split(','):
-            self._order_by += ((col, direction),)
+        for col in column.split(","):
+            self._order_by += (OrderByExpression(col, direction=direction),)
+        return self
+
+    def order_by_raw(self, query):
+        """Specifies a column to order by.
+
+        Arguments:
+            column {string} -- The name of the column.
+
+        Keyword Arguments:
+            direction {string} -- Specify either ASC or DESC order. (default: {"ASC"})
+
+        Returns:
+            self
+        """
+        self._order_by += (OrderByExpression(query, raw=True),)
         return self
 
     def group_by(self, column):

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1051,7 +1051,8 @@ class QueryBuilder(ObservesEvents):
         Returns:
             self
         """
-        self._order_by += ((column, direction),)
+        for col in column.split(','):
+            self._order_by += ((col, direction),)
         return self
 
     def group_by(self, column):

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -311,6 +311,14 @@ class BaseGrammar:
             for order_bys in self._order_by:
                 if order_bys.raw:
                     order_crit += order_bys.column
+                    if not isinstance(order_bys.bindings, (list, tuple)):
+                        raise ValueError(
+                            f"Bindings must be tuple or list. Received {type(where.bindings)}"
+                        )
+
+                    if order_bys.bindings:
+                        self.add_binding(*order_bys.bindings)
+
                     continue
 
                 if len(order_crit):

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -309,15 +309,20 @@ class BaseGrammar:
         if self._order_by:
             order_crit = ""
             for order_bys in self._order_by:
+                if order_bys.raw:
+                    order_crit += order_bys.column
+                    continue
+
                 if len(order_crit):
                     order_crit += ", "
-                column, direction = order_bys
+                column = order_bys.column
+                direction = order_bys.direction
                 order_crit += self.order_by_format().format(
                     column=self._table_column_string(column),
                     direction=direction.upper(),
                 )
-            sql = self.order_by_string().format(order_columns=order_crit)
 
+            sql += self.order_by_string().format(order_columns=order_crit)
         return sql
 
     def process_group_by(self):

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -266,7 +266,7 @@ class BaseTestQueryBuilder:
 
     def test_order_by_reference_direction(self):
         builder = self.get_builder()
-        builder.order_by("email, name as desc")
+        builder.order_by("email, name desc")
         sql = getattr(
             self, inspect.currentframe().f_code.co_name.replace("test_", "")
         )()

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -264,6 +264,22 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_order_by_reference_direction(self):
+        builder = self.get_builder()
+        builder.order_by("email, name as desc")
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_order_by_raw(self):
+        builder = self.get_builder()
+        builder.order_by_raw("col asc")
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_order_by_desc(self):
         builder = self.get_builder()
         builder.order_by("email", "desc")
@@ -593,7 +609,19 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         """
         builder.order_by('email', 'asc')
         """
-        return """SELECT * FROM "users" ORDER BY "users"."email" ASC, "users"." name" ASC, "users"." active" ASC"""
+        return """SELECT * FROM "users" ORDER BY "users"."email" ASC, "users"."name" ASC, "users"."active" ASC"""
+
+    def order_by_raw(self):
+        """
+        builder.order_by('email', 'asc')
+        """
+        return """SELECT * FROM "users" ORDER BY col asc"""
+
+    def order_by_reference_direction(self):
+        """
+        builder.order_by('email', 'asc')
+        """
+        return """SELECT * FROM "users" ORDER BY "users"."email" ASC, "users"."name" DESC"""
 
     def order_by_desc(self):
         """

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -256,6 +256,14 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_order_by_multiple(self):
+        builder = self.get_builder()
+        builder.order_by("email, name, active")
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_order_by_desc(self):
         builder = self.get_builder()
         builder.order_by("email", "desc")
@@ -580,6 +588,12 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.order_by('email', 'asc')
         """
         return """SELECT * FROM "users" ORDER BY "users"."email" ASC"""
+
+    def order_by_multiple(self):
+        """
+        builder.order_by('email', 'asc')
+        """
+        return """SELECT * FROM "users" ORDER BY "users"."email" ASC, "users"." name" ASC, "users"." active" ASC"""
 
     def order_by_desc(self):
         """


### PR DESCRIPTION
Closes #329 

This PR adds the ability to specify a comma separated list in the order by method:

These 2 peices of code are the same

```python
#== 1
store.order_by("name").order_by('location')

#== 2
store.order_by("name, location")
```

You will have to mix for getting different sort directions:

```python
store.order_by("name").order_by("location", "desc")
```

Also adds the ability to specify column direction directly in the order by:

These 2 pieces of code are the same:

```python
store.order_by("name").order_by("location", "desc")
store.order_by("name, location desc")
```

This PR also adds an order by raw:

```python
store.order_by_raw("name desc")
```