### PR TITLE
added selects

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -68,6 +68,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
     __table__ = None
     __connection__ = "default"
     __resolved_connection__ = None
+    __selects__ = []
 
     __observers__ = []
 
@@ -180,7 +181,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             dry=self.__dry__,
         )
 
-        return self.builder
+        return self.builder.select(*self.__selects__)
 
     def get_connection_details(self):
         from config.database import ConnectionResolver

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1267,12 +1267,13 @@ class QueryBuilder(ObservesEvents):
             hydrated_model.add_relation({relation_key: related_result or None})
         return self
 
-    def all(self, query=False):
+    def all(self, selects=[], query=False):
         """Returns all records from the table.
 
         Returns:
             dictionary -- Returns a dictionary of results.
         """
+        self.select(*selects)
         if query:
             return self.to_sql()
 
@@ -1280,12 +1281,13 @@ class QueryBuilder(ObservesEvents):
 
         return self.prepare_result(result, collection=True)
 
-    def get(self):
+    def get(self, selects=[]):
         """Runs the select query built from the query builder.
 
         Returns:
             self
         """
+        self.select(*selects)
         result = self.new_connection().query(self.to_qmark(), self._bindings)
 
         return self.prepare_result(result, collection=True)

--- a/tests/sqlite/models/test_sqlite_model.py
+++ b/tests/sqlite/models/test_sqlite_model.py
@@ -16,6 +16,17 @@ class User(Model):
     __dry__ = True
 
 
+class Select(Model):
+    __connection__ = "dev"
+    __selects__ = ["username", "rememember_token as token"]
+    __dry__ = True
+
+
+class SelectPass(Model):
+    __connection__ = "dev"
+    __dry__ = True
+
+
 class BaseTestQueryRelationships(unittest.TestCase):
 
     maxDiff = None
@@ -49,3 +60,15 @@ class BaseTestQueryRelationships(unittest.TestCase):
         user = User.hydrate({"id": 1, "name": "joe", "customer_id": 1})
         user.customer_id = "CUST1"
         self.assertEqual(user.customer_id, "CUST1")
+
+    def test_model_can_use_selects(self):
+        self.assertEqual(
+            Select.to_sql(),
+            'SELECT "selects"."username", "selects"."rememember_token" AS token FROM "selects"',
+        )
+
+    def test_model_can_use_selects_from_methods(self):
+        self.assertEqual(
+            SelectPass.all(["username"], query=True),
+            'SELECT "select_passes"."username" FROM "select_passes"',
+        )


### PR DESCRIPTION
Closes #302 

Adds 3 new ways to select:

Adding it directly to a model:

```python
class Store(Model):
    __selects__ = ["username", "password as secret"]
```

In the `all` method:

```python
store.all(["username", "password as secret"])
```

and in the get 

```python
store.where("active", 1).get(["username"])
```