### PR TITLE
added group by fixes

### DIFF
--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -100,7 +100,6 @@ class OrderByExpression:
         self.column = column.strip()
 
         self.raw = raw
-        self.alias = None
 
         self.direction = direction
         self.bindings = bindings
@@ -113,3 +112,13 @@ class OrderByExpression:
             if self.column.endswith(" asc"):
                 self.column = self.column.split(" asc")[0].strip()
                 self.direction = "ASC"
+
+
+class GroupByExpression:
+    """A helper class to manage select expressions."""
+
+    def __init__(self, column=None, raw=False, bindings=()):
+        self.column = column.strip()
+
+        self.raw = raw
+        self.bindings = bindings

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1086,7 +1086,7 @@ class QueryBuilder(ObservesEvents):
 
         return self
 
-    def group_by_raw(self, query):
+    def group_by_raw(self, query, bindings=()):
         """Specifies a column to group by.
 
         Arguments:
@@ -1095,7 +1095,9 @@ class QueryBuilder(ObservesEvents):
         Returns:
             self
         """
-        self._group_by += (GroupByExpression(column=query, raw=True),)
+        self._group_by += (
+            GroupByExpression(column=query, raw=True, bindings=bindings),
+        )
 
         return self
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -6,6 +6,7 @@ from ..expressions.expressions import (
     SubSelectExpression,
     SelectExpression,
     BetweenExpression,
+    GroupByExpression,
     QueryExpression,
     OrderByExpression,
     UpdateQueryExpression,
@@ -1080,7 +1081,22 @@ class QueryBuilder(ObservesEvents):
         Returns:
             self
         """
-        self._group_by += (column,)
+        for col in column.split(","):
+            self._group_by += (GroupByExpression(column=col),)
+
+        return self
+
+    def group_by_raw(self, query):
+        """Specifies a column to group by.
+
+        Arguments:
+            column {string} -- The name of the column to group by.
+
+        Returns:
+            self
+        """
+        self._group_by += (GroupByExpression(column=query, raw=True),)
+
         return self
 
     def aggregate(self, aggregate, column):

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -343,8 +343,12 @@ class BaseGrammar:
         columns = []
         for group_by in self._group_by:
             if group_by.raw:
+                if group_by.bindings:
+                    self.add_binding(*group_by.bindings)
+
                 sql += "GROUP BY " + group_by.column
                 return sql
+
             else:
                 columns.append(self._table_column_string(group_by.column))
 

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -313,7 +313,7 @@ class BaseGrammar:
                     order_crit += order_bys.column
                     if not isinstance(order_bys.bindings, (list, tuple)):
                         raise ValueError(
-                            f"Bindings must be tuple or list. Received {type(where.bindings)}"
+                            f"Bindings must be tuple or list. Received {type(order_bys.bindings)}"
                         )
 
                     if order_bys.bindings:
@@ -340,9 +340,16 @@ class BaseGrammar:
             self
         """
         sql = ""
-        for group_bys in self._group_by:
-            column = group_bys
-            sql += "GROUP BY {column}".format(column=self._table_column_string(column))
+        columns = []
+        for group_by in self._group_by:
+            if group_by.raw:
+                sql += "GROUP BY " + group_by.column
+                return sql
+            else:
+                columns.append(self._table_column_string(group_by.column))
+
+        if columns:
+            sql += " GROUP BY {column}".format(column=", ".join(columns))
 
         return sql
 

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -367,6 +367,31 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_group_by_raw(self):
+        builder = self.get_builder(table="payments")
+        builder.select("user_id").min("salary").group_by_raw("count(*)")
+
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_group_by_multiple(self):
+        builder = self.get_builder(table="payments")
+        builder.select("user_id").min("salary").group_by("user_id").group_by("salary")
+
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_group_by_multiple_in_same_group_by(self):
+        builder = self.get_builder(table="payments")
+        builder.select("user_id").min("salary").group_by("user_id, salary")
+
+        sql = getattr(self, "group_by_multiple")()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_builder_alone(self):
         self.assertTrue(
             QueryBuilder(
@@ -682,6 +707,18 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.select('user_id').min('salary').group_by('user_id')
         """
         return """SELECT "payments"."user_id", MIN("payments"."salary") AS salary FROM "payments" GROUP BY "payments"."user_id\""""
+
+    def group_by_multiple(self):
+        """
+        builder.select('user_id').min('salary').group_by('user_id')
+        """
+        return """SELECT "payments"."user_id", MIN("payments"."salary") AS salary FROM "payments" GROUP BY "payments"."user_id", "payments"."salary\""""
+
+    def group_by_raw(self):
+        """
+        builder.select('user_id').min('salary').group_by('user_id')
+        """
+        return """SELECT "payments"."user_id", MIN("payments"."salary") AS salary FROM "payments" GROUP BY count(*)"""
 
     def where_lt(self):
         """


### PR DESCRIPTION
Closes #338 

This PR fixes an issue when using multiple group bys and adds the ability to specify multiple group by columns as we do with order by columns:

```python
.group_by("col1, col2")
```

Also adds group by raw:

```python
.group_by_raw("COUNT(*)")
```