### PR TITLE
Feature/344

### DIFF
--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -122,3 +122,12 @@ class GroupByExpression:
 
         self.raw = raw
         self.bindings = bindings
+
+
+class AggregateExpression:
+    def __init__(self, aggregate=None, column=None, alias=False):
+        self.aggregate = aggregate
+        self.column = column.strip()
+        self.alias = alias
+        if " as " in self.column:
+            self.column, self.alias = self.column.split(" as ")

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -7,6 +7,7 @@ from ..expressions.expressions import (
     SelectExpression,
     BetweenExpression,
     GroupByExpression,
+    AggregateExpression,
     QueryExpression,
     OrderByExpression,
     UpdateQueryExpression,
@@ -1101,14 +1102,16 @@ class QueryBuilder(ObservesEvents):
 
         return self
 
-    def aggregate(self, aggregate, column):
+    def aggregate(self, aggregate, column, alias=None):
         """Helper function to aggregate.
 
         Arguments:
             aggregate {string} -- The name of the aggregation.
             column {string} -- The name of the column to aggregate.
         """
-        self._aggregates += ((aggregate, column),)
+        self._aggregates += (
+            AggregateExpression(aggregate=aggregate, column=column, alias=alias),
+        )
 
     def first(self, query=False):
         """Gets the first record.

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1018,12 +1018,15 @@ class QueryBuilder(ObservesEvents):
         Returns:
             self
         """
-        self.aggregate("COUNT", "{column}".format(column=column))
+        self.aggregate("COUNT", f"{column} as m_count_reserved")
 
         if self.dry:
             return self
 
         result = self.new_connection().query(self.to_qmark(), self._bindings, results=1)
+
+        if isinstance(result, dict):
+            return result["m_count_reserved"]
 
         prepared_result = list(result.values())
         if not prepared_result:

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1018,7 +1018,7 @@ class QueryBuilder(ObservesEvents):
         Returns:
             self
         """
-        self.aggregate("COUNT", f"{column} as m_count_reserved")
+        self.aggregate("COUNT", "{column} as {alias}".format(column=column, alias="m_count_reserved" if column == "*" else column))
 
         if self.dry:
             return self

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -284,7 +284,8 @@ class BaseGrammar:
         """
         sql = ""
         for aggregates in self._aggregates:
-            aggregate, column = aggregates
+            aggregate = aggregates.aggregate
+            column = aggregates.column
             aggregate_function = self.aggregate_options.get(aggregate, "")
             if column == "*":
                 aggregate_string = self.aggregate_string_without_alias()
@@ -294,7 +295,7 @@ class BaseGrammar:
             sql += aggregate_string.format(
                 aggregate_function=aggregate_function,
                 column="*" if column == "*" else self._table_column_string(column),
-                alias=self.process_alias(column),
+                alias=self.process_alias(aggregates.alias or column),
             )
 
         return sql

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -287,7 +287,7 @@ class BaseGrammar:
             aggregate = aggregates.aggregate
             column = aggregates.column
             aggregate_function = self.aggregate_options.get(aggregate, "")
-            if column == "*":
+            if not aggregates.alias and column == "*":
                 aggregate_string = self.aggregate_string_without_alias()
             else:
                 aggregate_string = self.aggregate_string_with_alias()

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -140,7 +140,7 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         self.builder.count().to_sql()
         """
 
-        return "SELECT COUNT(*) FROM [users]"
+        return "SELECT COUNT(*) AS m_count_reserved FROM [users]"
 
     def can_compile_count_column(self):
         """

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -146,7 +146,7 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         self.builder.count().to_sql()
         """
 
-        return "SELECT COUNT(*) FROM `users`"
+        return "SELECT COUNT(*) AS m_count_reserved FROM `users`"
 
     def can_compile_count_column(self):
         """

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -142,7 +142,7 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         self.builder.count().to_sql()
         """
 
-        return """SELECT COUNT(*) FROM "users\""""
+        return """SELECT COUNT(*) AS m_count_reserved FROM "users\""""
 
     def can_compile_count_column(self):
         """

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -34,6 +34,29 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_sum_aggregate(self):
+        builder = self.get_builder()
+        builder.aggregate("SUM", "age")
+
+        sql = getattr(self, "sum")()
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_sum_aggregate_with_alias(self):
+        builder = self.get_builder()
+        builder.aggregate("SUM", "age", alias="number")
+
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_sum_aggregate_with_alias_in_column_name(self):
+        builder = self.get_builder()
+        builder.sum("age as number")
+
+        sql = getattr(self, "sum_aggregate_with_alias")()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_where_like(self):
         builder = self.get_builder()
         builder.where("age", "like", "%name%")
@@ -483,6 +506,13 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.sum('age')
         """
         return """SELECT SUM("users"."age") AS age FROM "users\""""
+
+    def sum_aggregate_with_alias(self):
+        """
+        builder = self.get_builder()
+        builder.sum('age')
+        """
+        return """SELECT SUM("users"."age") AS number FROM "users\""""
 
     def max(self):
         """

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -148,7 +148,7 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         self.builder.count().to_sql()
         """
 
-        return """SELECT COUNT(*) FROM "users\""""
+        return """SELECT COUNT(*) AS m_count_reserved FROM "users\""""
 
     def can_compile_count_column(self):
         """


### PR DESCRIPTION
Closes #344 

This adds the ability to specify aliases directly in the aggregate functions:

```python
builder.sum("activity as quantity")
```