### PR TITLE
adds add_select query builder method

### DIFF
--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -78,19 +78,22 @@ class SubSelectExpression:
 class SubGroupExpression:
     """A helper class to manage subgroup expressions."""
 
-    def __init__(self, builder):
+    def __init__(self, builder, alias="group"):
         self.builder = builder
+        self.alias = alias
 
 
 class SelectExpression:
     """A helper class to manage select expressions."""
 
     def __init__(self, column, raw=False):
-        self.column = column
+        self.column = column.strip()
         self.alias = None
         self.raw = raw
         if raw is False and " as " in self.column:
             self.column, self.alias = self.column.split(" as ")
+            self.column = self.column.strip()
+            self.alias = self.alias.strip()
 
 
 class OrderByExpression:

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -91,6 +91,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
     """
     __passthrough__ = [
         "all",
+        "add_select",
         "avg",
         "bulk_create",
         "chunk",

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -147,6 +147,17 @@ class QueryBuilder(ObservesEvents):
         self._table = table
         return self
 
+    def from_(self, table):
+        """Alias for the table method
+
+        Arguments:
+            table {string} -- The name of the table
+
+        Returns:
+            self
+        """
+        return self.table(table)
+
     def get_table_name(self):
         """Sets a table on the query builder
 

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -658,6 +658,13 @@ class BaseGrammar:
                     continue
 
                 column = column.column
+
+            if isinstance(column, SubGroupExpression):
+                builder_sql = column.builder.to_qmark()
+                sql += f"({builder_sql}) as {column.alias}, "
+                self.add_binding(*column.builder._bindings)
+                continue
+
             sql += self._table_column_string(column, alias=alias, separator=separator)
 
         if self._aggregates:

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -551,7 +551,7 @@ class BaseGrammar:
                             value=val, separator=","
                         )
                 query_value = query_value.rstrip(",").rstrip(", ") + ")"
-            elif qmark:
+            elif qmark and value_type != "column":
                 query_value = "'?'"
                 if (
                     value is not True

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -326,7 +326,6 @@ class BaseGrammar:
                     order_crit += ", "
                 column = order_bys.column
                 direction = order_bys.direction
-                print("column", column)
                 if "." in column:
                     column_string = self._table_column_string(column)
                 else:

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -662,7 +662,8 @@ class BaseGrammar:
             if isinstance(column, SubGroupExpression):
                 builder_sql = column.builder.to_qmark()
                 sql += f"({builder_sql}) as {column.alias}, "
-                self.add_binding(*column.builder._bindings)
+                if column.builder._bindings:
+                    self.add_binding(*column.builder._bindings)
                 continue
 
             sql += self._table_column_string(column, alias=alias, separator=separator)

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -326,9 +326,15 @@ class BaseGrammar:
                     order_crit += ", "
                 column = order_bys.column
                 direction = order_bys.direction
+                print("column", column)
+                if "." in column:
+                    column_string = self._table_column_string(column)
+                else:
+                    column_string = self.column_string().format(
+                        column=column, separator=""
+                    )
                 order_crit += self.order_by_format().format(
-                    column=self._table_column_string(column),
-                    direction=direction.upper(),
+                    column=column_string, direction=direction.upper()
                 )
 
             sql += self.order_by_string().format(order_columns=order_crit)

--- a/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
+++ b/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
@@ -183,7 +183,7 @@ class BaseTestCaseSelectGrammar:
         self.assertEqual(to_sql, sql)
 
     def test_can_compile_count(self):
-        to_sql = self.builder.count().to_sql()
+        to_sql = self.builder.count("*").to_sql()
         sql = getattr(
             self, inspect.currentframe().f_code.co_name.replace("test_", "")
         )()

--- a/tests/mssql/builder/test_mssql_query_builder.py
+++ b/tests/mssql/builder/test_mssql_query_builder.py
@@ -221,15 +221,13 @@ class TestMSSQLQueryBuilder(unittest.TestCase):
     def test_order_by_asc(self):
         builder = self.get_builder()
         builder.order_by("email", "asc")
-        self.assertEqual(
-            builder.to_sql(), "SELECT * FROM [users] ORDER BY [users].[email] ASC"
-        )
+        self.assertEqual(builder.to_sql(), "SELECT * FROM [users] ORDER BY [email] ASC")
 
     def test_order_by_desc(self):
         builder = self.get_builder()
         builder.order_by("email", "desc")
         self.assertEqual(
-            builder.to_sql(), "SELECT * FROM [users] ORDER BY [users].[email] DESC"
+            builder.to_sql(), "SELECT * FROM [users] ORDER BY [email] DESC"
         )
 
     def test_where_column(self):

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -49,7 +49,7 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.order_by('id', 'asc').first()
         """
-        return """SELECT TOP 1 * FROM [users] ORDER BY [users].[id] ASC"""
+        return """SELECT TOP 1 * FROM [users] ORDER BY [id] ASC"""
 
     def can_compile_with_max(self):
         """
@@ -73,13 +73,13 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.select('username').order_by('age', 'desc').to_sql()
         """
-        return "SELECT [users].[username] FROM [users] ORDER BY [users].[age] DESC"
+        return "SELECT [users].[username] FROM [users] ORDER BY [age] DESC"
 
     def can_compile_with_multiple_order_by(self):
         """
         self.builder.select('username').order_by('age', 'desc').order_by('name').to_sql()
         """
-        return "SELECT [users].[username] FROM [users] ORDER BY [users].[age] DESC, [users].[name] ASC"
+        return "SELECT [users].[username] FROM [users] ORDER BY [age] DESC, [name] ASC"
 
     def can_compile_with_group_by(self):
         """

--- a/tests/mysql/builder/test_query_builder.py
+++ b/tests/mysql/builder/test_query_builder.py
@@ -151,6 +151,19 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_add_select(self):
+        builder = self.get_builder()
+        sql = (
+            builder.select("name")
+            .add_select("phone_count", lambda q: q.count("*").table("phones"))
+            .add_select("salary", lambda q: q.count("*").table("salary"))
+            .to_sql()
+        )
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_create(self):
         builder = self.get_builder().without_global_scopes()
         builder.create(
@@ -554,6 +567,13 @@ class MySQLQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.select_raw('count(email) as email_count')
         """
         return "SELECT count(email) as email_count FROM `users`"
+
+    def add_select(self):
+        """
+        builder = self.get_builder()
+        builder.select('name', 'email')
+        """
+        return "SELECT `users`.`name`, (SELECT COUNT(*) AS m_count_reserved FROM `phones`) as phone_count, (SELECT COUNT(*) AS m_count_reserved FROM `salary`) as salary FROM `users`"
 
     def create(self):
         """

--- a/tests/mysql/builder/test_query_builder.py
+++ b/tests/mysql/builder/test_query_builder.py
@@ -663,13 +663,13 @@ class MySQLQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         """
         builder.order_by('email', 'asc')
         """
-        return "SELECT * FROM `users` ORDER BY `users`.`email` ASC"
+        return "SELECT * FROM `users` ORDER BY `email` ASC"
 
     def order_by_desc(self):
         """
         builder.order_by('email', 'des')
         """
-        return "SELECT * FROM `users` ORDER BY `users`.`email` DESC"
+        return "SELECT * FROM `users` ORDER BY `email` DESC"
 
     def where_column(self):
         """

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -25,7 +25,7 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.order_by('id', 'asc').first()
         """
-        return """SELECT * FROM `users` ORDER BY `users`.`id` ASC LIMIT 1"""
+        return """SELECT * FROM `users` ORDER BY `id` ASC LIMIT 1"""
 
     def can_compile_with_where(self):
         """
@@ -73,13 +73,13 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.select('username').order_by('age', 'desc').to_sql()
         """
-        return "SELECT `users`.`username` FROM `users` ORDER BY `users`.`age` DESC"
+        return "SELECT `users`.`username` FROM `users` ORDER BY `age` DESC"
 
     def can_compile_with_multiple_order_by(self):
         """
         self.builder.select('username').order_by('age', 'desc').order_by('name').to_sql()
         """
-        return "SELECT `users`.`username` FROM `users` ORDER BY `users`.`age` DESC, `users`.`name` ASC"
+        return "SELECT `users`.`username` FROM `users` ORDER BY `age` DESC, `name` ASC"
 
     def can_compile_with_group_by(self):
         """

--- a/tests/postgres/builder/test_postgres_query_builder.py
+++ b/tests/postgres/builder/test_postgres_query_builder.py
@@ -567,13 +567,13 @@ class PostgresQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         """
         builder.order_by('email', 'asc')
         """
-        return """SELECT * FROM "users" ORDER BY "users"."email" ASC"""
+        return """SELECT * FROM "users" ORDER BY "email" ASC"""
 
     def order_by_desc(self):
         """
         builder.order_by('email', 'des')
         """
-        return """SELECT * FROM "users" ORDER BY "users"."email" DESC"""
+        return """SELECT * FROM "users" ORDER BY "email" DESC"""
 
     def where_column(self):
         """

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -67,13 +67,15 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.select('username').order_by('age', 'desc').to_sql()
         """
-        return """SELECT "users"."username" FROM "users" ORDER BY "users"."age" DESC"""
+        return """SELECT "users"."username" FROM "users" ORDER BY "age" DESC"""
 
     def can_compile_with_multiple_order_by(self):
         """
         self.builder.select('username').order_by('age', 'desc').order_by('name').to_sql()
         """
-        return """SELECT "users"."username" FROM "users" ORDER BY "users"."age" DESC, "users"."name" ASC"""
+        return (
+            """SELECT "users"."username" FROM "users" ORDER BY "age" DESC, "name" ASC"""
+        )
 
     def can_compile_with_group_by(self):
         """
@@ -223,7 +225,7 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.order_by('id', 'asc').first()
         """
-        return """SELECT * FROM "users" ORDER BY "users"."id" ASC LIMIT 1"""
+        return """SELECT * FROM "users" ORDER BY "id" ASC LIMIT 1"""
 
     def can_compile_having_with_greater_than_expression(self):
         """

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -161,6 +161,7 @@ class BaseTestQueryBuilder:
         sql = (
             builder.select("name")
             .add_select("phone_count", lambda q: q.count("*").table("phones"))
+            .add_select("salary", lambda q: q.count("*").table("salary"))
             .to_sql()
         )
         sql = getattr(
@@ -593,7 +594,7 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder = self.get_builder()
         builder.select('name', 'email')
         """
-        return """SELECT "users"."name", (SELECT COUNT(*) AS m_count_reserved FROM "phones") as phone_count FROM "users\""""
+        return """SELECT "users"."name", (SELECT COUNT(*) AS m_count_reserved FROM "phones") as phone_count, (SELECT COUNT(*) AS m_count_reserved FROM "salary") as salary FROM "users\""""
 
     def select_raw(self):
         """

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -691,13 +691,15 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         """
         builder.order_by('email', 'asc')
         """
-        return """SELECT * FROM "users" ORDER BY "users"."email" ASC"""
+        return """SELECT * FROM "users" ORDER BY "email" ASC"""
 
     def order_by_multiple(self):
         """
         builder.order_by('email', 'asc')
         """
-        return """SELECT * FROM "users" ORDER BY "users"."email" ASC, "users"."name" ASC, "users"."active" ASC"""
+        return (
+            """SELECT * FROM "users" ORDER BY "email" ASC, "name" ASC, "active" ASC"""
+        )
 
     def order_by_raw(self):
         """
@@ -709,13 +711,13 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         """
         builder.order_by('email', 'asc')
         """
-        return """SELECT * FROM "users" ORDER BY "users"."email" ASC, "users"."name" DESC"""
+        return """SELECT * FROM "users" ORDER BY "email" ASC, "name" DESC"""
 
     def order_by_desc(self):
         """
         builder.order_by('email', 'des')
         """
-        return """SELECT * FROM "users" ORDER BY "users"."email" DESC"""
+        return """SELECT * FROM "users" ORDER BY "email" DESC"""
 
     def where_column(self):
         """

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -150,6 +150,24 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_select_multiple(self):
+        builder = self.get_builder()
+        builder.select("name, email")
+        sql = getattr(self, "select")()
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_add_select(self):
+        builder = self.get_builder()
+        sql = (
+            builder.select("name")
+            .add_select("phone_count", lambda q: q.count("*").table("phones"))
+            .to_sql()
+        )
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_select_raw(self):
         builder = self.get_builder()
         builder.select_raw("count(email) as email_count")
@@ -562,6 +580,20 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.select('name', 'email')
         """
         return """SELECT "users"."name", "users"."email" FROM "users\""""
+
+    def select_multiple(self):
+        """
+        builder = self.get_builder()
+        builder.select('name', 'email')
+        """
+        return """SELECT "users"."name", "users"."email" FROM "users\""""
+
+    def add_select(self):
+        """
+        builder = self.get_builder()
+        builder.select('name', 'email')
+        """
+        return """SELECT "users"."name", (SELECT COUNT(*) AS m_count_reserved FROM "phones") as phone_count FROM "users\""""
 
     def select_raw(self):
         """

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -19,7 +19,7 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.order_by('id', 'asc').first()
         """
-        return """SELECT * FROM "users" ORDER BY "users"."id" ASC LIMIT 1"""
+        return """SELECT * FROM "users" ORDER BY "id" ASC LIMIT 1"""
 
     def can_compile_with_columns(self):
         """
@@ -73,13 +73,15 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.select('username').order_by('age', 'desc').to_sql()
         """
-        return """SELECT "users"."username" FROM "users" ORDER BY "users"."age" DESC"""
+        return """SELECT "users"."username" FROM "users" ORDER BY "age" DESC"""
 
     def can_compile_with_multiple_order_by(self):
         """
         self.builder.select('username').order_by('age', 'desc').order_by('name').to_sql()
         """
-        return """SELECT "users"."username" FROM "users" ORDER BY "users"."age" DESC, "users"."name" ASC"""
+        return (
+            """SELECT "users"."username" FROM "users" ORDER BY "age" DESC, "name" ASC"""
+        )
 
     def can_compile_with_group_by(self):
         """


### PR DESCRIPTION
Closes #350 

This PR adds support for `add_select`. This is a builder method that allows you to add a select expression to the select clause of a query. This query is usually used to order by an aggregate on a separate table.

For example, If you have stores and products, this can be used to order by stores that have the most sales. A query might look like this:

```python
Store.add_select("sales", lambda query: (
    query.count("*").from_("sales").where_column("sales.store_id", stores.id"")
)).order_by("sales", "desc")
```

## Other Changes

* This changes the way order by's are called. Previously it was using "table.column" but this doesn't work when ordering by an alias. So now the group by now just orders by whatever you pass to it, like an alias or column name
* This PR adds a `from_` method which is an alias to the query builder
* Changed count to only call if no parameters are passed to it