### PR TITLE
Add deleted_at attribute setting

### DIFF
--- a/src/masoniteorm/scopes/SoftDeleteScope.py
+++ b/src/masoniteorm/scopes/SoftDeleteScope.py
@@ -4,6 +4,9 @@ from .BaseScope import BaseScope
 class SoftDeleteScope(BaseScope):
     """Global scope class to add soft deleting to models."""
 
+    def __init__(self, deleted_at_column="deleted_at"):
+        self.deleted_at_column = deleted_at_column
+
     def on_boot(self, builder):
         builder.set_global_scope("_where_null", self._where_null, action="select")
         builder.set_global_scope(
@@ -19,7 +22,7 @@ class SoftDeleteScope(BaseScope):
         builder.remove_global_scope("_query_set_null_on_delete", action="delete")
 
     def _where_null(self, builder):
-        return builder.where_null(builder._model.get_deleted_at_column())
+        return builder.where_null(self.deleted_at_column)
 
     def _with_trashed(self, model, builder):
         builder.remove_global_scope("_where_null", action="select")
@@ -27,15 +30,15 @@ class SoftDeleteScope(BaseScope):
 
     def _only_trashed(self, model, builder):
         builder.remove_global_scope("_where_null", action="select")
-        return builder.where_not_null(builder._model.get_deleted_at_column())
+        return builder.where_not_null(self.deleted_at_column)
 
     def _force_delete(self, model, builder):
         return builder.remove_global_scope(self).set_action("delete")
 
     def _restore(self, model, builder):
-        return builder.remove_global_scope(self).update({builder._model.get_deleted_at_column(): None})
+        return builder.remove_global_scope(self).update({self.deleted_at_column: None})
 
     def _query_set_null_on_delete(self, builder):
         return builder.set_action("update").set_updates(
-            {builder._model.get_deleted_at_column(): builder._model.get_new_datetime_string()}
+            {self.deleted_at_column: builder._model.get_new_datetime_string()}
         )

--- a/src/masoniteorm/scopes/SoftDeleteScope.py
+++ b/src/masoniteorm/scopes/SoftDeleteScope.py
@@ -19,7 +19,7 @@ class SoftDeleteScope(BaseScope):
         builder.remove_global_scope("_query_set_null_on_delete", action="delete")
 
     def _where_null(self, builder):
-        return builder.where_null("deleted_at")
+        return builder.where_null(builder._model.get_deleted_at_column())
 
     def _with_trashed(self, model, builder):
         builder.remove_global_scope("_where_null", action="select")
@@ -27,15 +27,15 @@ class SoftDeleteScope(BaseScope):
 
     def _only_trashed(self, model, builder):
         builder.remove_global_scope("_where_null", action="select")
-        return builder.where_not_null("deleted_at")
+        return builder.where_not_null(builder._model.get_deleted_at_column())
 
     def _force_delete(self, model, builder):
         return builder.remove_global_scope(self).set_action("delete")
 
     def _restore(self, model, builder):
-        return builder.remove_global_scope(self).update({"deleted_at": None})
+        return builder.remove_global_scope(self).update({builder._model.get_deleted_at_column(): None})
 
     def _query_set_null_on_delete(self, builder):
         return builder.set_action("update").set_updates(
-            {"deleted_at": builder._model.get_new_datetime_string()}
+            {builder._model.get_deleted_at_column(): builder._model.get_new_datetime_string()}
         )

--- a/src/masoniteorm/scopes/SoftDeletesMixin.py
+++ b/src/masoniteorm/scopes/SoftDeletesMixin.py
@@ -4,5 +4,10 @@ from .SoftDeleteScope import SoftDeleteScope
 class SoftDeletesMixin:
     """Global scope class to add soft deleting to models."""
 
+    __deleted_at__ = "deleted_at"
+
     def boot_SoftDeletesMixin(self, builder):
         builder.set_global_scope(SoftDeleteScope())
+
+    def get_deleted_at_column(self):
+        return self.__deleted_at__

--- a/src/masoniteorm/scopes/SoftDeletesMixin.py
+++ b/src/masoniteorm/scopes/SoftDeletesMixin.py
@@ -7,7 +7,7 @@ class SoftDeletesMixin:
     __deleted_at__ = "deleted_at"
 
     def boot_SoftDeletesMixin(self, builder):
-        builder.set_global_scope(SoftDeleteScope())
+        builder.set_global_scope(SoftDeleteScope(self.__deleted_at__))
 
     def get_deleted_at_column(self):
         return self.__deleted_at__


### PR DESCRIPTION
Fixes #297 

Well actually I tried it out and it's not that simple (at least for me)
The tests for soft delete are done at query builder level, without model involved, so `builder._model` is None and we cannot fetch the name of the deleted_at column. => The only place where it has been defined is when calling `soft_deletes()` in the migration file (where the default value "deleted_at" can be overriden).

```python
def _only_trashed(self, model, builder):
    builder.remove_global_scope("_where_null", action="select")
    # => builder._model is None here when using query builder and not model
    return builder.where_not_null(builder._model.get_deleted_at_column())
```

So I am not sure how to proceed then, we should maybe use a switch to fetch the column name depending if the model is defined 🤔 ? Does not look very solid to me.

@Marlysson @josephmancuso some insights ?