### PR TITLE
Fix double type in postgres. Changed to double precision.

### DIFF
--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -25,7 +25,7 @@ class PostgresPlatform(Platform):
         "binary": "LONGBLOB",
         "boolean": "BOOLEAN",
         "decimal": "DECIMAL",
-        "double": "DOUBLE",
+        "double": "DOUBLE PRECISION",
         "enum": "VARCHAR(255) CHECK ",
         "text": "TEXT",
         "float": "FLOAT",

--- a/tests/postgres/schema/test_postgres_schema_builder.py
+++ b/tests/postgres/schema/test_postgres_schema_builder.py
@@ -119,6 +119,7 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
             blueprint.datetime("published_at")
             blueprint.string("thumbnail").nullable()
             blueprint.integer("premium")
+            blueprint.double("amount").default(0.0)
             blueprint.integer("author_id").unsigned().nullable()
             blueprint.foreign("author_id").references("id").on("authors").on_delete(
                 "CASCADE"
@@ -126,13 +127,13 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
             blueprint.text("description")
             blueprint.timestamps()
 
-        self.assertEqual(len(blueprint.table.added_columns), 14)
+        self.assertEqual(len(blueprint.table.added_columns), 15)
         self.assertEqual(
             blueprint.to_sql(),
             (
                 'CREATE TABLE "users" (id SERIAL UNIQUE NOT NULL, name VARCHAR(255) NOT NULL, '
                 "duration VARCHAR(255) NOT NULL, money DECIMAL(17, 6) NOT NULL, url VARCHAR(255) NOT NULL, option VARCHAR(255) NOT NULL DEFAULT 'ADMIN', payload JSONB NOT NULL, published_at TIMESTAMP NOT NULL, "
-                "thumbnail VARCHAR(255) NULL, premium INTEGER NOT NULL, author_id INT NULL, "
+                "thumbnail VARCHAR(255) NULL, premium INTEGER NOT NULL, amount DOUBLE PRECISION NOT NULL DEFAULT 0.0, author_id INT NULL, "
                 "description TEXT NOT NULL, created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
                 "updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
                 "CONSTRAINT users_author_id_foreign FOREIGN KEY (author_id) REFERENCES authors(id))"


### PR DESCRIPTION
Fix the postgres double type error.
There's the types for do that: REAL and DOUBLE PRECISION. I've defined as DOUBLE PRECISION ( until need change, I'll keep this )