### PR TITLE
Fixed error when was used the enum type in postgres

### DIFF
--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -398,8 +398,16 @@ class Blueprint:
         for option in options:
             new_options += "'{}',".format(option)
         new_options = new_options.rstrip(",")
+
         self._last_column = self.table.add_column(
-            column, "enum", length=new_options, nullable=nullable
+            column, "enum", length=255, nullable=nullable
+        )
+
+        self.table.add_constraint(
+            self._last_column.name,
+            "check",
+            columns=[self._last_column.name],
+            values=new_options,
         )
         return self
 

--- a/src/masoniteorm/schema/Constraint.py
+++ b/src/masoniteorm/schema/Constraint.py
@@ -1,5 +1,6 @@
 class Constraint:
-    def __init__(self, name, constraint_type, columns=None):
+    def __init__(self, name, constraint_type, columns=None, values=None):
         self.name = name
         self.constraint_type = constraint_type
         self.columns = columns or []
+        self.values = values

--- a/src/masoniteorm/schema/Table.py
+++ b/src/masoniteorm/schema/Table.py
@@ -22,13 +22,15 @@ class Table:
         column = Column(
             name, column_type, length=length, nullable=nullable, default=default
         )
+
         self.added_columns.update({name: column})
         return column
 
-    def add_constraint(self, name, constraint_type, columns=None):
-        self.added_constraints.update(
-            {name: Constraint(name, constraint_type, columns=columns or [])}
+    def add_constraint(self, name, constraint_type, columns=None, values=None):
+        constraint = Constraint(
+            name, constraint_type, columns=columns or [], values=values
         )
+        self.added_constraints.update({name: constraint})
 
     def add_foreign_key(self, column, table=None, foreign_column=None):
         foreign_key = ForeignKeyConstraint(column, table, foreign_column)

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -26,7 +26,7 @@ class PostgresPlatform(Platform):
         "boolean": "BOOLEAN",
         "decimal": "DECIMAL",
         "double": "DOUBLE",
-        "enum": "VARCHAR(255) CHECK ",
+        "enum": "VARCHAR",
         "text": "TEXT",
         "float": "FLOAT",
         "geometry": "GEOMETRY",
@@ -235,6 +235,7 @@ class PostgresPlatform(Platform):
                 )().format(
                     columns=", ".join(constraint.columns),
                     name_columns="_".join(constraint.columns),
+                    values=constraint.values,
                     table=table.name,
                 )
             )
@@ -248,6 +249,9 @@ class PostgresPlatform(Platform):
 
     def get_unique_constraint_string(self):
         return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"
+
+    def get_check_constraint_string(self):
+        return "CONSTRAINT {table}_{name_columns}_check CHECK ({name_columns} IN ({values}))"
 
     def get_table_string(self):
         return '"{table}"'

--- a/tests/postgres/schema/test_postgres_schema_builder.py
+++ b/tests/postgres/schema/test_postgres_schema_builder.py
@@ -167,6 +167,20 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
             'CREATE TABLE "integer_types" (tiny TINYINT NOT NULL, small SMALLINT NOT NULL, medium MEDIUMINT NOT NULL, big BIGINT NOT NULL)',
         )
 
+    def test_can_add_check_constraint(self):
+        with self.schema.create('people') as table:
+            table.increments("id")
+            table.string("name")
+            table.enum("gender", ["male", "female"])
+
+        self.assertEqual(len(table.table.added_columns), 3)
+        self.assertEqual(len(table.table.added_constraints), 1)
+
+        self.assertEqual(table.to_sql(),
+            'CREATE TABLE "people" (id SERIAL UNIQUE NOT NULL, name VARCHAR(255) NOT NULL, gender VARCHAR(255) NOT NULL, ' \
+            'CONSTRAINT people_gender_check CHECK (gender IN (\'male\',\'female\')))'
+        )
+
     def test_can_enable_foreign_keys(self):
         sql = self.schema.enable_foreign_key_constraints()
 


### PR DESCRIPTION
Closes #359 
@josephmancuso It's done and I had to change somethings.

1. Removed the CHECK from mapped types because when the process of "columnize" start, then it was placed in `length` position ( acting as length of column ) for some way, making it impossible change it ( I think that was a bug ).
2. Added `values` in Constraint model to represent the values that the column will compare against.
3. Created constraint `get_[constraint]_string` in platform.

No break change with this changes.
