### PR TITLE
Added support for queries without a table

### DIFF
--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1425,7 +1425,6 @@ class QueryBuilder(ObservesEvents):
 
         # Either _creates when creating, otherwise use columns
         columns = self._creates or self._columns
-        print("ss", self._creates)
 
         return self.grammar(
             columns=columns,

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -408,7 +408,6 @@ class BaseGrammar:
         Returns:
             self
         """
-        print("t", table)
         if not table:
             return ""
         return ".".join(
@@ -694,7 +693,7 @@ class BaseGrammar:
 
             if isinstance(column, SubGroupExpression):
                 builder_sql = column.builder.to_qmark()
-                sql += f"({builder_sql}) as {column.alias}, "
+                sql += f"({builder_sql}) AS {column.alias}, "
                 if column.builder._bindings:
                     self.add_binding(*column.builder._bindings)
                 continue

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -72,22 +72,40 @@ class BaseGrammar:
         Returns:
             [type] -- [description]
         """
-        self._sql = (
-            self.select_format()
-            .format(
-                columns=self.process_columns(separator=", "),
-                table=self.process_table(self.table),
-                wheres=self.process_wheres(qmark=qmark),
-                limit=self.process_limit(),
-                offset=self.process_offset(),
-                aggregates=self.process_aggregates(),
-                order_by=self.process_order_by(),
-                group_by=self.process_group_by(),
-                joins=self.process_joins(),
-                having=self.process_having(),
+        if not self.table:
+            self._sql = (
+                self.select_no_table()
+                .format(
+                    columns=self.process_columns(separator=", "),
+                    table=self.process_table(self.table),
+                    wheres=self.process_wheres(qmark=qmark),
+                    limit=self.process_limit(),
+                    offset=self.process_offset(),
+                    aggregates=self.process_aggregates(),
+                    order_by=self.process_order_by(),
+                    group_by=self.process_group_by(),
+                    joins=self.process_joins(),
+                    having=self.process_having(),
+                )
+                .strip()
             )
-            .strip()
-        )
+        else:
+            self._sql = (
+                self.select_format()
+                .format(
+                    columns=self.process_columns(separator=", "),
+                    table=self.process_table(self.table),
+                    wheres=self.process_wheres(qmark=qmark),
+                    limit=self.process_limit(),
+                    offset=self.process_offset(),
+                    aggregates=self.process_aggregates(),
+                    order_by=self.process_order_by(),
+                    group_by=self.process_group_by(),
+                    joins=self.process_joins(),
+                    having=self.process_having(),
+                )
+                .strip()
+            )
 
         return self
 
@@ -390,6 +408,9 @@ class BaseGrammar:
         Returns:
             self
         """
+        print("t", table)
+        if not table:
+            return ""
         return ".".join(
             self.table_string().format(
                 table=t,

--- a/src/masoniteorm/query/grammars/MSSQLGrammar.py
+++ b/src/masoniteorm/query/grammars/MSSQLGrammar.py
@@ -30,6 +30,9 @@ class MSSQLGrammar(BaseGrammar):
         "delete": "{table}.[{column}]{separator}",
     }
 
+    def select_no_table(self):
+        return "SELECT {columns}"
+
     def select_format(self):
         return "SELECT {limit} {columns} FROM {table} {joins} {wheres} {group_by} {order_by} {offset} {having}"
 

--- a/src/masoniteorm/query/grammars/MySQLGrammar.py
+++ b/src/masoniteorm/query/grammars/MySQLGrammar.py
@@ -81,6 +81,9 @@ class MySQLGrammar(BaseGrammar):
     def select_format(self):
         return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {order_by} {limit} {offset} {having}"
 
+    def select_no_table(self):
+        return "SELECT {columns}"
+
     def update_format(self):
         return "UPDATE {table} SET {key_equals} {wheres}"
 
@@ -132,6 +135,8 @@ class MySQLGrammar(BaseGrammar):
         Returns:
             self
         """
+        if not table:
+            return ""
         return ".".join(self.table_string().format(table=t) for t in table.split("."))
 
     def subquery_alias_string(self):

--- a/src/masoniteorm/query/grammars/PostgresGrammar.py
+++ b/src/masoniteorm/query/grammars/PostgresGrammar.py
@@ -31,6 +31,9 @@ class PostgresGrammar(BaseGrammar):
         "delete": '{table}."{column}"{separator}',
     }
 
+    def select_no_table(self):
+        return "SELECT {columns}"
+
     def select_format(self):
         return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {order_by} {limit} {offset} {having}"
 

--- a/src/masoniteorm/query/grammars/SQLiteGrammar.py
+++ b/src/masoniteorm/query/grammars/SQLiteGrammar.py
@@ -34,6 +34,9 @@ class SQLiteGrammar(BaseGrammar):
     def select_format(self):
         return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {order_by} {limit} {offset} {having}"
 
+    def select_no_table(self):
+        return "SELECT {columns}"
+
     def update_format(self):
         return "UPDATE {table} SET {key_equals} {wheres}"
 

--- a/tests/mysql/builder/test_query_builder.py
+++ b/tests/mysql/builder/test_query_builder.py
@@ -23,6 +23,8 @@ class User(Model):
 
 
 class BaseTestQueryBuilder:
+    maxDiff = None
+
     def get_builder(self, table="users"):
         connection = MockConnectionFactory().make("default")
         return QueryBuilder(
@@ -157,6 +159,22 @@ class BaseTestQueryBuilder:
             builder.select("name")
             .add_select("phone_count", lambda q: q.count("*").table("phones"))
             .add_select("salary", lambda q: q.count("*").table("salary"))
+            .to_sql()
+        )
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_add_select_no_table(self):
+        builder = self.get_builder(table=None)
+        sql = (
+            builder.add_select(
+                "other_test", lambda q: q.max("updated_at").table("different_table")
+            )
+            .add_select(
+                "some_alias", lambda q: q.max("updated_at").table("another_table")
+            )
             .to_sql()
         )
         sql = getattr(
@@ -573,7 +591,18 @@ class MySQLQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder = self.get_builder()
         builder.select('name', 'email')
         """
-        return "SELECT `users`.`name`, (SELECT COUNT(*) AS m_count_reserved FROM `phones`) as phone_count, (SELECT COUNT(*) AS m_count_reserved FROM `salary`) as salary FROM `users`"
+        return "SELECT `users`.`name`, (SELECT COUNT(*) AS m_count_reserved FROM `phones`) AS phone_count, (SELECT COUNT(*) AS m_count_reserved FROM `salary`) AS salary FROM `users`"
+
+    def add_select_no_table(self):
+        """
+        builder = self.get_builder()
+        builder.select('name', 'email')
+        """
+        return (
+            "SELECT "
+            "(SELECT MAX(`different_table`.`updated_at`) AS updated_at FROM `different_table`) AS other_test, "
+            "(SELECT MAX(`another_table`.`updated_at`) AS updated_at FROM `another_table`) AS some_alias"
+        )
 
     def create(self):
         """

--- a/tests/postgres/builder/test_postgres_query_builder.py
+++ b/tests/postgres/builder/test_postgres_query_builder.py
@@ -119,6 +119,22 @@ class BaseTestQueryBuilder:
         )()
         self.assertEqual(builder.to_sql(), sql)
 
+    def test_add_select_no_table(self):
+        builder = self.get_builder(table=None)
+        sql = (
+            builder.add_select(
+                "other_test", lambda q: q.max("updated_at").table("different_table")
+            )
+            .add_select(
+                "some_alias", lambda q: q.max("updated_at").table("another_table")
+            )
+            .to_sql()
+        )
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
     def test_select_raw(self):
         builder = self.get_builder()
         builder.select_raw("count(email) as email_count")
@@ -471,6 +487,17 @@ class PostgresQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.select('name', 'email')
         """
         return """SELECT "users"."name", "users"."email" FROM "users\""""
+
+    def add_select_no_table(self):
+        """
+        builder = self.get_builder()
+        builder.select('name', 'email')
+        """
+        return (
+            "SELECT "
+            '(SELECT MAX("different_table"."updated_at") AS updated_at FROM "different_table") AS other_test, '
+            '(SELECT MAX("another_table"."updated_at") AS updated_at FROM "another_table") AS some_alias'
+        )
 
     def select_raw(self):
         """

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -15,6 +15,8 @@ class UserMock(Model):
 
 
 class BaseTestQueryBuilder:
+    maxDiff = None
+
     def get_builder(self, table="users"):
         connection = MockConnectionFactory().make("sqlite")
         return QueryBuilder(
@@ -162,6 +164,22 @@ class BaseTestQueryBuilder:
             builder.select("name")
             .add_select("phone_count", lambda q: q.count("*").table("phones"))
             .add_select("salary", lambda q: q.count("*").table("salary"))
+            .to_sql()
+        )
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_add_select_no_table(self):
+        builder = self.get_builder(table=None)
+        sql = (
+            builder.add_select(
+                "other_test", lambda q: q.max("updated_at").table("different_table")
+            )
+            .add_select(
+                "some_alias", lambda q: q.max("updated_at").table("another_table")
+            )
             .to_sql()
         )
         sql = getattr(
@@ -595,6 +613,17 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder.select('name', 'email')
         """
         return """SELECT "users"."name", (SELECT COUNT(*) AS m_count_reserved FROM "phones") as phone_count, (SELECT COUNT(*) AS m_count_reserved FROM "salary") as salary FROM "users\""""
+
+    def add_select_no_table(self):
+        """
+        builder = self.get_builder()
+        builder.select('name', 'email')
+        """
+        return (
+            "SELECT "
+            '(SELECT MAX("different_table"."updated_at") AS updated_at FROM "different_table") AS other_test, '
+            '(SELECT MAX("another_table"."updated_at") AS updated_at FROM "another_table") AS some_alias'
+        )
 
     def select_raw(self):
         """

--- a/tests/sqlite/builder/test_sqlite_query_builder.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder.py
@@ -612,7 +612,7 @@ class SQLiteQueryBuilderTest(BaseTestQueryBuilder, unittest.TestCase):
         builder = self.get_builder()
         builder.select('name', 'email')
         """
-        return """SELECT "users"."name", (SELECT COUNT(*) AS m_count_reserved FROM "phones") as phone_count, (SELECT COUNT(*) AS m_count_reserved FROM "salary") as salary FROM "users\""""
+        return """SELECT "users"."name", (SELECT COUNT(*) AS m_count_reserved FROM "phones") AS phone_count, (SELECT COUNT(*) AS m_count_reserved FROM "salary") AS salary FROM "users\""""
 
     def add_select_no_table(self):
         """


### PR DESCRIPTION
Closes #378 

I'm not 100% how we're going to do this but there is an issue when you want to run a select query without a table. Right now we hard code the FROM so you can't run selects without a table but when i research this its valid SQL sometimes but not really

Should generate a query for something like this:

```sql
SELECT
	(SELECT MAX(updated_at) AS updated_at FROM different_table) AS other_test,
	(SELECT MAX(updated_at) AS updated_at FROM another_table) AS some_alias;
```

Add support for:

- [x] MSSQL
- [x] MySQL
- [x] Postgres
- [x] SQLite
- [ ] Limits and other clauses ?