### PR TITLE
Fix missing registered observer command

### DIFF
--- a/src/masoniteorm/providers/ORMProvider.py
+++ b/src/masoniteorm/providers/ORMProvider.py
@@ -5,6 +5,7 @@ from masoniteorm.connections import ConnectionResolver
 from masoniteorm.commands import (
     MakeMigrationCommand,
     MakeSeedCommand,
+    MakeObserverCommand,
     MigrateCommand,
     MigrateRefreshCommand,
     MigrateRollbackCommand,
@@ -22,6 +23,7 @@ class ORMProvider(ServiceProvider):
         self.commands(
             MakeMigrationCommand(),
             MakeSeedCommand(),
+            MakeObserverCommand(),
             MigrateCommand(),
             MigrateRefreshCommand(),
             MigrateRollbackCommand(),


### PR DESCRIPTION
`python craft observer ...` raises an error `observer command is not defined` because this ORM command is not registered