### PR TITLE
Feature/422

### DIFF
--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -628,7 +628,7 @@ class Blueprint:
     def soft_deletes(self, name="deleted_at"):
         return self.datetime(name, nullable=True).nullable()
 
-    def unique(self, column=None):
+    def unique(self, column=None, name=None):
         """Sets the last column to be unique if no column name is passed.
 
         If a column name is passed this method will create a new unique column.
@@ -649,12 +649,12 @@ class Blueprint:
             column = [column]
 
         self.table.add_constraint(
-            f"{self.table.name}_{'_'.join(column)}_unique", "unique", columns=column
+            name or f"{self.table.name}_{'_'.join(column)}_unique", "unique", columns=column
         )
 
         return self
 
-    def index(self, column):
+    def index(self, column, name=None):
         """Creates a constraint based on the index constraint representation of the table.
 
         Arguments:
@@ -667,12 +667,12 @@ class Blueprint:
             column = [column]
 
         self.table.add_index(
-            column, f"{self.table.name}_{'_'.join(column)}_index", "index"
+            column, name or f"{self.table.name}_{'_'.join(column)}_index", "index"
         )
 
         return self
 
-    def fulltext(self, column):
+    def fulltext(self, column, name=None):
         """Creates a constraint based on the full text constraint representation of the table.
 
         Arguments:
@@ -684,7 +684,7 @@ class Blueprint:
         if not isinstance(column, list):
             column = [column]
 
-        self.table.add_constraint(f"{'_'.join(column)}_fulltext", "fulltext", column)
+        self.table.add_constraint(name or f"{'_'.join(column)}_fulltext", "fulltext", column)
 
         return self
 

--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -705,7 +705,7 @@ class Blueprint:
 
         return self
 
-    def foreign(self, column):
+    def foreign(self, column, name=None):
         """Starts the creation of a foreign key constraint
 
         Arguments:
@@ -714,7 +714,7 @@ class Blueprint:
         Returns:
             self
         """
-        self._last_foreign = self.table.add_foreign_key(column)
+        self._last_foreign = self.table.add_foreign_key(column, name=name or f"{self.table.name}_{column}_foreign")
         return self
 
     def references(self, column):

--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -649,7 +649,9 @@ class Blueprint:
             column = [column]
 
         self.table.add_constraint(
-            name or f"{self.table.name}_{'_'.join(column)}_unique", "unique", columns=column
+            name or f"{self.table.name}_{'_'.join(column)}_unique",
+            "unique",
+            columns=column,
         )
 
         return self
@@ -684,7 +686,9 @@ class Blueprint:
         if not isinstance(column, list):
             column = [column]
 
-        self.table.add_constraint(name or f"{'_'.join(column)}_fulltext", "fulltext", column)
+        self.table.add_constraint(
+            name or f"{'_'.join(column)}_fulltext", "fulltext", column
+        )
 
         return self
 
@@ -714,7 +718,9 @@ class Blueprint:
         Returns:
             self
         """
-        self._last_foreign = self.table.add_foreign_key(column, name=name or f"{self.table.name}_{column}_foreign")
+        self._last_foreign = self.table.add_foreign_key(
+            column, name=name or f"{self.table.name}_{column}_foreign"
+        )
         return self
 
     def references(self, column):

--- a/src/masoniteorm/schema/ForeignKeyConstraint.py
+++ b/src/masoniteorm/schema/ForeignKeyConstraint.py
@@ -1,10 +1,11 @@
 class ForeignKeyConstraint:
-    def __init__(self, column, foreign_table, foreign_column):
+    def __init__(self, column, foreign_table, foreign_column, name=None):
         self.column = column
         self.foreign_table = foreign_table
         self.foreign_column = foreign_column
         self.delete_action = None
         self.update_action = None
+        self.constraint_name = name
 
     def references(self, foreign_column):
         self.foreign_column = foreign_column
@@ -20,4 +21,8 @@ class ForeignKeyConstraint:
 
     def on_update(self, action):
         self.update_action = action
+        return self
+
+    def name(self, name):
+        self.constraint_name = name
         return self

--- a/src/masoniteorm/schema/Table.py
+++ b/src/masoniteorm/schema/Table.py
@@ -45,7 +45,9 @@ class Table:
         )
 
     def add_foreign_key(self, column, table=None, foreign_column=None, name=None):
-        foreign_key = ForeignKeyConstraint(column, table, foreign_column, name=name or f"{self.name}_{column}_foreign")
+        foreign_key = ForeignKeyConstraint(
+            column, table, foreign_column, name=name or f"{self.name}_{column}_foreign"
+        )
         self.added_foreign_keys.update({column: foreign_key})
 
         return foreign_key

--- a/src/masoniteorm/schema/Table.py
+++ b/src/masoniteorm/schema/Table.py
@@ -44,8 +44,8 @@ class Table:
             {name: Constraint(name, constraint_type, columns=columns or [])}
         )
 
-    def add_foreign_key(self, column, table=None, foreign_column=None):
-        foreign_key = ForeignKeyConstraint(column, table, foreign_column)
+    def add_foreign_key(self, column, table=None, foreign_column=None, name=None):
+        foreign_key = ForeignKeyConstraint(column, table, foreign_column, name=name or f"{self.name}_{column}_foreign")
         self.added_foreign_keys.update({column: foreign_key})
 
         return foreign_key

--- a/src/masoniteorm/schema/platforms/MSSQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MSSQLPlatform.py
@@ -172,9 +172,6 @@ class MSSQLPlatform(Platform):
                     )
                 elif constraint.constraint_type == "fulltext":
                     pass
-                    # sql.append(
-                    #     f"ALTER TABLE {self.wrap_table(table.name)} ADD FULLTEXT {constraint.name}({','.join(constraint.columns)})"
-                    # )
         return sql
 
     def add_column_string(self):
@@ -262,7 +259,7 @@ class MSSQLPlatform(Platform):
         return "ALTER TABLE {table} {columns}"
 
     def get_foreign_key_constraint_string(self):
-        return "CONSTRAINT {table}_{clean_column}_foreign FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
+        return "CONSTRAINT {constraint_name} FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
 
     def get_unique_constraint_string(self):
         return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"

--- a/src/masoniteorm/schema/platforms/MSSQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MSSQLPlatform.py
@@ -130,6 +130,7 @@ class MSSQLPlatform(Platform):
                     f"ALTER TABLE {self.wrap_table(table.name)} ADD "
                     + self.get_foreign_key_constraint_string().format(
                         clean_column=column,
+                        constraint_name=foreign_key_constraint.constraint_name,
                         column=self.wrap_table(column),
                         table=table.name,
                         foreign_table=foreign_key_constraint.foreign_table,

--- a/src/masoniteorm/schema/platforms/MySQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MySQLPlatform.py
@@ -229,6 +229,7 @@ class MySQLPlatform(Platform):
                     f"ALTER TABLE {self.wrap_table(table.name)} ADD "
                     + self.get_foreign_key_constraint_string().format(
                         column=column,
+                        constraint_name=foreign_key_constraint.constraint_name,
                         table=table.name,
                         foreign_table=foreign_key_constraint.foreign_table,
                         foreign_column=foreign_key_constraint.foreign_column,
@@ -316,7 +317,7 @@ class MySQLPlatform(Platform):
         return "ALTER TABLE {table} {columns}"
 
     def get_foreign_key_constraint_string(self):
-        return "CONSTRAINT {table}_{column}_foreign FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
+        return "CONSTRAINT {constraint_name} FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
 
     def get_unique_constraint_string(self):
         return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"

--- a/src/masoniteorm/schema/platforms/Platform.py
+++ b/src/masoniteorm/schema/platforms/Platform.py
@@ -66,6 +66,7 @@ class Platform:
                 self.get_foreign_key_constraint_string().format(
                     column=foreign_key.column,
                     clean_column=foreign_key.column,
+                    constraint_name=foreign_key.constraint_name,
                     table=table,
                     foreign_table=foreign_key.foreign_table,
                     foreign_column=foreign_key.foreign_column,

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -247,6 +247,7 @@ class PostgresPlatform(Platform):
                     f"ALTER TABLE {self.wrap_table(table.name)} ADD "
                     + self.get_foreign_key_constraint_string().format(
                         column=column,
+                        constraint_name=foreign_key_constraint.constraint_name,
                         table=table.name,
                         foreign_table=foreign_key_constraint.foreign_table,
                         foreign_column=foreign_key_constraint.foreign_column,
@@ -320,7 +321,7 @@ class PostgresPlatform(Platform):
         return "CREATE TABLE {table} ({columns}{constraints}{foreign_keys})"
 
     def get_foreign_key_constraint_string(self):
-        return "CONSTRAINT {table}_{column}_foreign FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
+        return "CONSTRAINT {constraint_name} FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
 
     def get_unique_constraint_string(self):
         return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"

--- a/src/masoniteorm/schema/platforms/SQLitePlatform.py
+++ b/src/masoniteorm/schema/platforms/SQLitePlatform.py
@@ -255,7 +255,7 @@ class SQLitePlatform(Platform):
         return "UNIQUE({columns})"
 
     def get_foreign_key_constraint_string(self):
-        return "CONSTRAINT {table}_{column}_foreign FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
+        return "CONSTRAINT {constraint_name} FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
 
     def constraintize(self, constraints):
         sql = []
@@ -278,6 +278,7 @@ class SQLitePlatform(Platform):
             sql.append(
                 self.get_foreign_key_constraint_string().format(
                     column=foreign_key.column,
+                    constraint_name=foreign_key.constraint_name,
                     table=table,
                     foreign_table=foreign_key.foreign_table,
                     foreign_column=foreign_key.foreign_column,

--- a/tests/mssql/schema/test_mssql_schema_builder.py
+++ b/tests/mssql/schema/test_mssql_schema_builder.py
@@ -110,6 +110,19 @@ class TestMSSQLSchemaBuilder(unittest.TestCase):
             ),
         )
 
+    def test_can_add_columns_with_foreign_key_constraint_name(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.integer("profile_id")
+            blueprint.foreign("profile_id", name="profile_foreign").references("id").on("profiles")
+
+        self.assertEqual(len(blueprint.table.added_columns), 1)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE [users] ('
+            "[profile_id] INT NOT NULL, "
+            "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
+        )
+
     def test_has_table(self):
         schema_sql = self.schema.has_table("users")
 

--- a/tests/mssql/schema/test_mssql_schema_builder.py
+++ b/tests/mssql/schema/test_mssql_schema_builder.py
@@ -113,12 +113,14 @@ class TestMSSQLSchemaBuilder(unittest.TestCase):
     def test_can_add_columns_with_foreign_key_constraint_name(self):
         with self.schema.create("users") as blueprint:
             blueprint.integer("profile_id")
-            blueprint.foreign("profile_id", name="profile_foreign").references("id").on("profiles")
+            blueprint.foreign("profile_id", name="profile_foreign").references("id").on(
+                "profiles"
+            )
 
         self.assertEqual(len(blueprint.table.added_columns), 1)
         self.assertEqual(
             blueprint.to_sql(),
-            'CREATE TABLE [users] ('
+            "CREATE TABLE [users] ("
             "[profile_id] INT NOT NULL, "
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -125,6 +125,19 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             ),
         )
 
+    def test_can_add_columns_with_foreign_key_constraint_name(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.integer("profile_id")
+            blueprint.foreign("profile_id", name="profile_foreign").references("id").on("profiles")
+
+        self.assertEqual(len(blueprint.table.added_columns), 1)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE `users` ('
+            "`profile_id` INT(11) NOT NULL, "
+            "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
+        )
+
     def test_has_table(self):
         schema_sql = self.schema.has_table("users")
 

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -128,12 +128,14 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
     def test_can_add_columns_with_foreign_key_constraint_name(self):
         with self.schema.create("users") as blueprint:
             blueprint.integer("profile_id")
-            blueprint.foreign("profile_id", name="profile_foreign").references("id").on("profiles")
+            blueprint.foreign("profile_id", name="profile_foreign").references("id").on(
+                "profiles"
+            )
 
         self.assertEqual(len(blueprint.table.added_columns), 1)
         self.assertEqual(
             blueprint.to_sql(),
-            'CREATE TABLE `users` ('
+            "CREATE TABLE `users` ("
             "`profile_id` INT(11) NOT NULL, "
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )

--- a/tests/postgres/schema/test_postgres_schema_builder.py
+++ b/tests/postgres/schema/test_postgres_schema_builder.py
@@ -156,6 +156,19 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
             'CREATE TABLE "users" (id CHAR(36) NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL, public_id CHAR(36) NULL)',
         )
 
+    def test_can_add_columns_with_foreign_key_constraint_name(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.integer("profile_id")
+            blueprint.foreign("profile_id", name="profile_foreign").references("id").on("profiles")
+
+        self.assertEqual(len(blueprint.table.added_columns), 1)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE "users" ('
+            'profile_id INTEGER NOT NULL, '
+            "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
+        )
+
     def test_can_add_other_integer_types_column(self):
         with self.schema.create("integer_types") as table:
             table.tiny_integer("tiny")

--- a/tests/postgres/schema/test_postgres_schema_builder.py
+++ b/tests/postgres/schema/test_postgres_schema_builder.py
@@ -159,13 +159,15 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
     def test_can_add_columns_with_foreign_key_constraint_name(self):
         with self.schema.create("users") as blueprint:
             blueprint.integer("profile_id")
-            blueprint.foreign("profile_id", name="profile_foreign").references("id").on("profiles")
+            blueprint.foreign("profile_id", name="profile_foreign").references("id").on(
+                "profiles"
+            )
 
         self.assertEqual(len(blueprint.table.added_columns), 1)
         self.assertEqual(
             blueprint.to_sql(),
             'CREATE TABLE "users" ('
-            'profile_id INTEGER NOT NULL, '
+            "profile_id INTEGER NOT NULL, "
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )
 

--- a/tests/sqlite/schema/test_sqlite_schema_builder.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder.py
@@ -63,7 +63,9 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             blueprint.string("name").unique()
             blueprint.integer("age")
             blueprint.integer("profile_id")
-            blueprint.foreign("profile_id", name="profile_foreign").references("id").on("profiles")
+            blueprint.foreign("profile_id", name="profile_foreign").references("id").on(
+                "profiles"
+            )
 
         self.assertEqual(len(blueprint.table.added_columns), 3)
         self.assertEqual(

--- a/tests/sqlite/schema/test_sqlite_schema_builder.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder.py
@@ -58,6 +58,24 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             "CONSTRAINT users_profile_id_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )
 
+    def test_can_add_columns_with_foreign_key_constraint_name(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.string("name").unique()
+            blueprint.integer("age")
+            blueprint.integer("profile_id")
+            blueprint.foreign("profile_id", name="profile_foreign").references("id").on("profiles")
+
+        self.assertEqual(len(blueprint.table.added_columns), 3)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE "users" '
+            "(name VARCHAR(255) NOT NULL, "
+            "age INTEGER NOT NULL, "
+            "profile_id INTEGER NOT NULL, "
+            "UNIQUE(name), "
+            "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
+        )
+
     def test_can_use_morphs_for_polymorphism_relationships(self):
         with self.schema.create("likes") as blueprint:
             blueprint.morphs("record")

--- a/tests/sqlite/schema/test_sqlite_schema_builder.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder.py
@@ -98,6 +98,7 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
     def test_can_create_indexes(self):
         with self.schema.table("users") as blueprint:
             blueprint.index("name")
+            blueprint.index("active", "active_idx")
             blueprint.index(["name", "email"])
             blueprint.unique("name")
             blueprint.unique(["name", "email"])
@@ -109,6 +110,7 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             blueprint.to_sql(),
             [
                 'CREATE INDEX users_name_index ON "users"(name)',
+                'CREATE INDEX active_idx ON "users"(active)',
                 'CREATE INDEX users_name_email_index ON "users"(name,email)',
                 'CREATE UNIQUE INDEX users_name_unique ON "users"(name)',
                 'CREATE UNIQUE INDEX users_name_email_unique ON "users"(name,email)',


### PR DESCRIPTION
Closes #422 

This PR adds a high level way to change constraint names without needing to use low level methods.

For indexes:

```python
table.unique(["col1", "col2"], name="unique_idx")
table.index(["col1", "col2"], name="normal_idx")
table.foreign("col", name="col_foreign").references(..).on(..)
```