### PR TITLE
added primary key constraints for sqlite and mysql

### DIFF
--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -692,7 +692,7 @@ class Blueprint:
 
         return self
 
-    def primary(self, column=None):
+    def primary(self, column=None, name=None):
         """Creates a constraint based on the primary key constraint representation of the table.
         Sets the constraint on the last column if no column name is passed.
 
@@ -705,7 +705,16 @@ class Blueprint:
         if column is None:
             column = self._last_column.name
 
-        self.table.set_primary_key(column)
+        
+        if not isinstance(column, list):
+            column = [column]
+
+        self.table.add_constraint(
+            name or f"{self.table.name}_{'_'.join(column)}_primary",
+            "primary_key",
+            columns=column,
+        )
+
 
         return self
 

--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -705,7 +705,6 @@ class Blueprint:
         if column is None:
             column = self._last_column.name
 
-        
         if not isinstance(column, list):
             column = [column]
 
@@ -714,7 +713,6 @@ class Blueprint:
             "primary_key",
             columns=column,
         )
-
 
         return self
 

--- a/src/masoniteorm/schema/Table.py
+++ b/src/masoniteorm/schema/Table.py
@@ -67,9 +67,8 @@ class Table:
     def get_renamed_columns(self):
         return self.added_columns
 
-    def set_primary_key(self, column_name):
-        self.primary_key = column_name
-        self.added_columns[column_name].set_as_primary()
+    def set_primary_key(self, columns):
+        self.primary_key = columns
         return self
 
     def add_index(self, column, name, index_type):

--- a/src/masoniteorm/schema/platforms/MSSQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MSSQLPlatform.py
@@ -244,6 +244,7 @@ class MSSQLPlatform(Platform):
                 )().format(
                     columns=", ".join(constraint.columns),
                     name_columns="_".join(constraint.columns),
+                    constraint_name=constraint.name,
                     table=table.name,
                 )
             )
@@ -261,6 +262,9 @@ class MSSQLPlatform(Platform):
 
     def get_foreign_key_constraint_string(self):
         return "CONSTRAINT {constraint_name} FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
+
+    def get_primary_key_constraint_string(self):
+        return "CONSTRAINT {constraint_name} PRIMARY KEY ({columns})"
 
     def get_unique_constraint_string(self):
         return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"

--- a/src/masoniteorm/schema/platforms/MySQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MySQLPlatform.py
@@ -299,7 +299,7 @@ class MySQLPlatform(Platform):
                     columns=", ".join(constraint.columns),
                     name_columns="_".join(constraint.columns),
                     table=table.name,
-                    constraint_name=constraint.name
+                    constraint_name=constraint.name,
                 )
             )
 

--- a/src/masoniteorm/schema/platforms/MySQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MySQLPlatform.py
@@ -299,6 +299,7 @@ class MySQLPlatform(Platform):
                     columns=", ".join(constraint.columns),
                     name_columns="_".join(constraint.columns),
                     table=table.name,
+                    constraint_name=constraint.name
                 )
             )
 
@@ -318,6 +319,9 @@ class MySQLPlatform(Platform):
 
     def get_foreign_key_constraint_string(self):
         return "CONSTRAINT {constraint_name} FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
+
+    def get_primary_key_constraint_string(self):
+        return "CONSTRAINT {constraint_name} PRIMARY KEY ({columns})"
 
     def get_unique_constraint_string(self):
         return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -312,6 +312,7 @@ class PostgresPlatform(Platform):
                 )().format(
                     columns=", ".join(constraint.columns),
                     name_columns="_".join(constraint.columns),
+                    constraint_name=constraint.name,
                     table=table.name,
                 )
             )
@@ -322,6 +323,9 @@ class PostgresPlatform(Platform):
 
     def get_foreign_key_constraint_string(self):
         return "CONSTRAINT {constraint_name} FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
+
+    def get_primary_key_constraint_string(self):
+        return "CONSTRAINT {constraint_name} PRIMARY KEY ({columns})"
 
     def get_unique_constraint_string(self):
         return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"

--- a/src/masoniteorm/schema/platforms/SQLitePlatform.py
+++ b/src/masoniteorm/schema/platforms/SQLitePlatform.py
@@ -266,7 +266,10 @@ class SQLitePlatform(Platform):
             sql.append(
                 getattr(
                     self, f"get_{constraint.constraint_type}_constraint_string"
-                )().format(columns=", ".join(constraint.columns), constraint_name=constraint.name)
+                )().format(
+                    columns=", ".join(constraint.columns),
+                    constraint_name=constraint.name,
+                )
             )
         return sql
 

--- a/src/masoniteorm/schema/platforms/SQLitePlatform.py
+++ b/src/masoniteorm/schema/platforms/SQLitePlatform.py
@@ -257,13 +257,16 @@ class SQLitePlatform(Platform):
     def get_foreign_key_constraint_string(self):
         return "CONSTRAINT {constraint_name} FOREIGN KEY ({column}) REFERENCES {foreign_table}({foreign_column}){cascade}"
 
+    def get_primary_key_constraint_string(self):
+        return "CONSTRAINT {constraint_name} PRIMARY KEY ({columns})"
+
     def constraintize(self, constraints):
         sql = []
         for name, constraint in constraints.items():
             sql.append(
                 getattr(
                     self, f"get_{constraint.constraint_type}_constraint_string"
-                )().format(columns=", ".join(constraint.columns))
+                )().format(columns=", ".join(constraint.columns), constraint_name=constraint.name)
             )
         return sql
 

--- a/tests/mssql/schema/test_mssql_schema_builder.py
+++ b/tests/mssql/schema/test_mssql_schema_builder.py
@@ -125,6 +125,42 @@ class TestMSSQLSchemaBuilder(unittest.TestCase):
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )
 
+
+    def test_can_have_composite_keys(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.string("name").unique()
+            blueprint.integer("age")
+            blueprint.integer("profile_id")
+            blueprint.primary(['name', 'age'])
+
+        self.assertEqual(len(blueprint.table.added_columns), 3)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE [users] '
+            "([name] VARCHAR(255) NOT NULL, "
+            "[age] INT NOT NULL, "
+            "[profile_id] INT NOT NULL, "
+            "CONSTRAINT users_name_unique UNIQUE (name), "
+            "CONSTRAINT users_name_age_primary PRIMARY KEY (name, age))",
+        )
+
+    def test_can_have_column_primary_key(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.string("name").primary()
+            blueprint.integer("age")
+            blueprint.integer("profile_id")
+
+        self.assertEqual(len(blueprint.table.added_columns), 3)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE [users] '
+            "([name] VARCHAR(255) NOT NULL, "
+            "[age] INT NOT NULL, "
+            "[profile_id] INT NOT NULL, "
+            "CONSTRAINT users_name_primary PRIMARY KEY (name))",
+        )
+
+
     def test_has_table(self):
         schema_sql = self.schema.has_table("users")
 

--- a/tests/mssql/schema/test_mssql_schema_builder.py
+++ b/tests/mssql/schema/test_mssql_schema_builder.py
@@ -125,18 +125,17 @@ class TestMSSQLSchemaBuilder(unittest.TestCase):
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )
 
-
     def test_can_have_composite_keys(self):
         with self.schema.create("users") as blueprint:
             blueprint.string("name").unique()
             blueprint.integer("age")
             blueprint.integer("profile_id")
-            blueprint.primary(['name', 'age'])
+            blueprint.primary(["name", "age"])
 
         self.assertEqual(len(blueprint.table.added_columns), 3)
         self.assertEqual(
             blueprint.to_sql(),
-            'CREATE TABLE [users] '
+            "CREATE TABLE [users] "
             "([name] VARCHAR(255) NOT NULL, "
             "[age] INT NOT NULL, "
             "[profile_id] INT NOT NULL, "
@@ -153,13 +152,12 @@ class TestMSSQLSchemaBuilder(unittest.TestCase):
         self.assertEqual(len(blueprint.table.added_columns), 3)
         self.assertEqual(
             blueprint.to_sql(),
-            'CREATE TABLE [users] '
+            "CREATE TABLE [users] "
             "([name] VARCHAR(255) NOT NULL, "
             "[age] INT NOT NULL, "
             "[profile_id] INT NOT NULL, "
             "CONSTRAINT users_name_primary PRIMARY KEY (name))",
         )
-
 
     def test_has_table(self):
         schema_sql = self.schema.has_table("users")

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -91,10 +91,13 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             blueprint.integer("user_id").primary()
             blueprint.string("name")
             blueprint.string("email")
+
         self.assertEqual(len(blueprint.table.added_columns), 3)
+        self.assertEqual(len(blueprint.table.added_constraints), 1)
+
         self.assertTrue(
             blueprint.to_sql().startswith(
-                "CREATE TABLE `users` (`user_id` INT(11) NOT NULL PRIMARY KEY"
+                "CREATE TABLE `users` (`user_id` INT(11) NOT NULL"
             )
         )
 

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -140,6 +140,43 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )
 
+
+    def test_can_have_composite_keys(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.string("name").unique()
+            blueprint.integer("age")
+            blueprint.integer("profile_id")
+            blueprint.primary(['name', 'age'])
+
+        self.assertEqual(len(blueprint.table.added_columns), 3)
+        print(blueprint.to_sql())
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE `users` '
+            "(`name` VARCHAR(255) NOT NULL, "
+            "`age` INT(11) NOT NULL, "
+            "`profile_id` INT(11) NOT NULL, "
+            "CONSTRAINT users_name_unique UNIQUE (name), "
+            "CONSTRAINT users_name_age_primary PRIMARY KEY (name, age))",
+        )
+
+    def test_can_have_column_primary_key(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.string("name").primary()
+            blueprint.integer("age")
+            blueprint.integer("profile_id")
+
+        self.assertEqual(len(blueprint.table.added_columns), 3)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE `users` '
+            "(`name` VARCHAR(255) NOT NULL, "
+            "`age` INT(11) NOT NULL, "
+            "`profile_id` INT(11) NOT NULL, "
+            "CONSTRAINT users_name_primary PRIMARY KEY (name))",
+        )
+
+
     def test_has_table(self):
         schema_sql = self.schema.has_table("users")
 

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -143,19 +143,18 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )
 
-
     def test_can_have_composite_keys(self):
         with self.schema.create("users") as blueprint:
             blueprint.string("name").unique()
             blueprint.integer("age")
             blueprint.integer("profile_id")
-            blueprint.primary(['name', 'age'])
+            blueprint.primary(["name", "age"])
 
         self.assertEqual(len(blueprint.table.added_columns), 3)
         print(blueprint.to_sql())
         self.assertEqual(
             blueprint.to_sql(),
-            'CREATE TABLE `users` '
+            "CREATE TABLE `users` "
             "(`name` VARCHAR(255) NOT NULL, "
             "`age` INT(11) NOT NULL, "
             "`profile_id` INT(11) NOT NULL, "
@@ -172,13 +171,12 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
         self.assertEqual(len(blueprint.table.added_columns), 3)
         self.assertEqual(
             blueprint.to_sql(),
-            'CREATE TABLE `users` '
+            "CREATE TABLE `users` "
             "(`name` VARCHAR(255) NOT NULL, "
             "`age` INT(11) NOT NULL, "
             "`profile_id` INT(11) NOT NULL, "
             "CONSTRAINT users_name_primary PRIMARY KEY (name))",
         )
-
 
     def test_has_table(self):
         schema_sql = self.schema.has_table("users")

--- a/tests/postgres/schema/test_postgres_schema_builder.py
+++ b/tests/postgres/schema/test_postgres_schema_builder.py
@@ -153,7 +153,7 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
         self.assertEqual(len(table.table.added_columns), 3)
         self.assertEqual(
             table.to_sql(),
-            'CREATE TABLE "users" (id CHAR(36) NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL, public_id CHAR(36) NULL)',
+            'CREATE TABLE "users" (id CHAR(36) NOT NULL, name VARCHAR(255) NOT NULL, public_id CHAR(36) NULL, CONSTRAINT users_id_primary PRIMARY KEY (id))',
         )
 
     def test_can_add_columns_with_foreign_key_constraint_name(self):
@@ -170,6 +170,42 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
             "profile_id INTEGER NOT NULL, "
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )
+
+
+    def test_can_have_composite_keys(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.string("name").unique()
+            blueprint.integer("age")
+            blueprint.integer("profile_id")
+            blueprint.primary(['name', 'age'])
+
+        self.assertEqual(len(blueprint.table.added_columns), 3)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE "users" '
+            "(name VARCHAR(255) NOT NULL, "
+            "age INTEGER NOT NULL, "
+            "profile_id INTEGER NOT NULL, "
+            "CONSTRAINT users_name_unique UNIQUE (name), "
+            "CONSTRAINT users_name_age_primary PRIMARY KEY (name, age))",
+        )
+
+    def test_can_have_column_primary_key(self):
+        with self.schema.create("users") as blueprint:
+            blueprint.string("name").primary()
+            blueprint.integer("age")
+            blueprint.integer("profile_id")
+
+        self.assertEqual(len(blueprint.table.added_columns), 3)
+        self.assertEqual(
+            blueprint.to_sql(),
+            'CREATE TABLE "users" '
+            "(name VARCHAR(255) NOT NULL, "
+            "age INTEGER NOT NULL, "
+            "profile_id INTEGER NOT NULL, "
+            "CONSTRAINT users_name_primary PRIMARY KEY (name))",
+        )
+
 
     def test_can_add_other_integer_types_column(self):
         with self.schema.create("integer_types") as table:

--- a/tests/postgres/schema/test_postgres_schema_builder.py
+++ b/tests/postgres/schema/test_postgres_schema_builder.py
@@ -171,13 +171,12 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
             "CONSTRAINT profile_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id))",
         )
 
-
     def test_can_have_composite_keys(self):
         with self.schema.create("users") as blueprint:
             blueprint.string("name").unique()
             blueprint.integer("age")
             blueprint.integer("profile_id")
-            blueprint.primary(['name', 'age'])
+            blueprint.primary(["name", "age"])
 
         self.assertEqual(len(blueprint.table.added_columns), 3)
         self.assertEqual(
@@ -205,7 +204,6 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
             "profile_id INTEGER NOT NULL, "
             "CONSTRAINT users_name_primary PRIMARY KEY (name))",
         )
-
 
     def test_can_add_other_integer_types_column(self):
         with self.schema.create("integer_types") as table:

--- a/tests/sqlite/schema/test_sqlite_schema_builder.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder.py
@@ -158,7 +158,7 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
             blueprint.string("name").unique()
             blueprint.integer("age")
             blueprint.integer("profile_id")
-            blueprint.primary(['name', 'age'])
+            blueprint.primary(["name", "age"])
 
         self.assertEqual(len(blueprint.table.added_columns), 3)
         self.assertEqual(

--- a/tests/sqlite/schema/test_table.py
+++ b/tests/sqlite/schema/test_table.py
@@ -40,7 +40,7 @@ class TestTable(unittest.TestCase):
         table.add_column("name", "string")
         table.set_primary_key("id")
 
-        sql = 'CREATE TABLE "users" (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR NOT NULL)'
+        sql = 'CREATE TABLE "users" (id INTEGER NOT NULL, name VARCHAR NOT NULL)'
         self.assertEqual(sql, self.platform.compile_create_sql(table))
 
     def test_create_sql_with_unique_constraint(self):
@@ -51,7 +51,7 @@ class TestTable(unittest.TestCase):
         table.set_primary_key("id")
 
         sql = (
-            'CREATE TABLE "users" (id INTEGER PRIMARY KEY, name VARCHAR, UNIQUE(name))'
+            'CREATE TABLE "users" (id INTEGER, name VARCHAR, UNIQUE(name))'
         )
         self.platform.constraintize(table.get_added_constraints())
         self.assertEqual(self.platform.compile_create_sql(table), sql)
@@ -65,7 +65,7 @@ class TestTable(unittest.TestCase):
         table.add_constraint("email", "unique", ["email"])
         table.set_primary_key("id")
 
-        sql = 'CREATE TABLE "users" (id INTEGER NOT NULL PRIMARY KEY, email VARCHAR NOT NULL, name VARCHAR NOT NULL, UNIQUE(name), UNIQUE(email))'
+        sql = 'CREATE TABLE "users" (id INTEGER NOT NULL, email VARCHAR NOT NULL, name VARCHAR NOT NULL, UNIQUE(name), UNIQUE(email))'
         self.platform.constraintize(table.get_added_constraints())
         self.assertEqual(self.platform.compile_create_sql(table), sql)
 
@@ -77,7 +77,7 @@ class TestTable(unittest.TestCase):
         table.add_constraint("name", "unique", ["name", "email"])
         table.set_primary_key("id")
 
-        sql = 'CREATE TABLE "users" (id INTEGER NOT NULL PRIMARY KEY, email VARCHAR NOT NULL, name VARCHAR NOT NULL, UNIQUE(name, email))'
+        sql = 'CREATE TABLE "users" (id INTEGER NOT NULL, email VARCHAR NOT NULL, name VARCHAR NOT NULL, UNIQUE(name, email))'
         self.platform.constraintize(table.get_added_constraints())
         self.assertEqual(self.platform.compile_create_sql(table), sql)
 
@@ -92,7 +92,7 @@ class TestTable(unittest.TestCase):
 
         sql = (
             'CREATE TABLE "users" ('
-            "id INTEGER NOT NULL PRIMARY KEY, profile_id INTEGER NOT NULL, comment_id INTEGER NOT NULL, "
+            "id INTEGER NOT NULL, profile_id INTEGER NOT NULL, comment_id INTEGER NOT NULL, "
             "CONSTRAINT users_profile_id_foreign FOREIGN KEY (profile_id) REFERENCES profiles(id), "
             "CONSTRAINT users_comment_id_foreign FOREIGN KEY (comment_id) REFERENCES comments(id))"
         )

--- a/tests/sqlite/schema/test_table.py
+++ b/tests/sqlite/schema/test_table.py
@@ -50,9 +50,7 @@ class TestTable(unittest.TestCase):
         table.add_constraint("name", "unique", ["name"])
         table.set_primary_key("id")
 
-        sql = (
-            'CREATE TABLE "users" (id INTEGER, name VARCHAR, UNIQUE(name))'
-        )
+        sql = 'CREATE TABLE "users" (id INTEGER, name VARCHAR, UNIQUE(name))'
         self.platform.constraintize(table.get_added_constraints())
         self.assertEqual(self.platform.compile_create_sql(table), sql)
 


### PR DESCRIPTION
Closes #430 

This PR adds support for composite primary keys.

In order to do this we need to change primary keys on column to primary key constraints

### TODO:

- [x] Sqlite
- [x] MySQL
- [x] Postgres
- [x] MSSQL