### PR TITLE
Add only changed attributes during updates and add force mode

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -106,6 +106,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
     __timestamps__ = True
     __timezone__ = "UTC"
     __with__ = ()
+    __force_update__ = False
 
     date_created_at = "created_at"
     date_updated_at = "updated_at"

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -146,6 +146,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         "to_sql",
         "truncate",
         "update",
+        "force_update",
         "when",
         "where_has",
         "where_from_builder",

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1036,6 +1036,10 @@ class QueryBuilder(ObservesEvents):
                     changes.update({attribute: value})
             updates = changes
 
+        # do not perform update query if no changes
+        if len(updates.keys()) == 0:
+            return model if model else self
+
         self._updates = (UpdateQueryExpression(updates),)
         self.set_action("update")
         if dry or self.dry:

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1029,7 +1029,7 @@ class QueryBuilder(ObservesEvents):
             self.observe_events(model, "updating")
 
         # update only attributes with changes
-        if not model.__force_update__ and not force:
+        if model and not model.__force_update__ and not force:
             changes = {}
             for attribute, value in updates.items():
                 if model.__original_attributes__.get(attribute, None) != value:

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -72,3 +72,37 @@ class TestModels(unittest.TestCase):
         self.assertEqual(type(model.f), float)
         self.assertEqual(type(model.is_vip), bool)
         self.assertEqual(type(model.serialize()["is_vip"]), bool)
+
+    def test_model_update_without_changes(self):
+        model = ModelTest.hydrate(
+            {"id": 1, "username": "joe", "name": "Joe", "admin": True}
+        )
+
+        model.username = "joe"
+        model.name = "Bill"
+        sql = model.save(query=True)
+        self.assertTrue(sql.startswith("UPDATE"))
+        self.assertNotIn("username", sql)
+
+    def test_force_update_on_model_class(self):
+        ModelTest.__force_update__ = True
+        model = ModelTest.hydrate(
+            {"id": 1, "username": "joe", "name": "Joe", "admin": True}
+        )
+
+        model.username = "joe"
+        model.name = "Bill"
+        sql = model.save(query=True)
+        self.assertTrue(sql.startswith("UPDATE"))
+        self.assertIn("username", sql)
+        self.assertIn("name", sql)
+
+    def test_model_update_without_changes_at_all(self):
+        model = ModelTest.hydrate(
+            {"id": 1, "username": "joe", "name": "Joe", "admin": True}
+        )
+
+        model.username = "joe"
+        model.name = "Joe"
+        sql = model.save(query=True)
+        # it's working but update timestamps, the update should be discarded/abandonned ?

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -8,6 +8,11 @@ class ModelTest(Model):
     __casts__ = {"is_vip": "bool", "payload": "json", "x": "int", "f": "float"}
 
 
+class ModelTestForced(Model):
+    __table__ = "users"
+    __force_update__ = True
+
+
 class TestModels(unittest.TestCase):
     def test_model_can_access_str_dates_as_pendulum(self):
         model = ModelTest.hydrate({"user": "joe", "due_date": "2020-11-28 11:42:07"})
@@ -85,8 +90,7 @@ class TestModels(unittest.TestCase):
         self.assertNotIn("username", sql)
 
     def test_force_update_on_model_class(self):
-        ModelTest.__force_update__ = True
-        model = ModelTest.hydrate(
+        model = ModelTestForced.hydrate(
             {"id": 1, "username": "joe", "name": "Joe", "admin": True}
         )
 
@@ -105,4 +109,4 @@ class TestModels(unittest.TestCase):
         model.username = "joe"
         model.name = "Joe"
         sql = model.save(query=True)
-        # it's working but update timestamps, the update should be discarded/abandonned ?
+        self.assertFalse(sql.startswith("UPDATE"))

--- a/tests/sqlite/models/test_sqlite_model.py
+++ b/tests/sqlite/models/test_sqlite_model.py
@@ -16,6 +16,14 @@ class User(Model):
     __dry__ = True
 
 
+class UserForced(Model):
+    __connection__ = "dev"
+    __table__ = "users"
+    __timestamps__ = False
+    __dry__ = True
+    __force_update__ = True
+
+
 class Select(Model):
     __connection__ = "dev"
     __selects__ = ["username", "rememember_token as token"]
@@ -71,4 +79,45 @@ class BaseTestQueryRelationships(unittest.TestCase):
         self.assertEqual(
             SelectPass.all(["username"], query=True),
             'SELECT "select_passes"."username" FROM "select_passes"',
+        )
+
+    def test_update_only_changed_attributes(self):
+        user = User.first()
+        sql = user.update({"name": user.name, "username": "new"}).to_sql()
+        # unchanged name attribute is not updated
+        self.assertEqual(
+            sql,
+            """UPDATE "users" SET "username" = 'new' WHERE "id" = '{}'""".format(
+                user.id
+            ),
+        )
+
+    def test_can_force_update_on_method(self):
+        user = User.first()
+        sql = user.update({"name": user.name, "username": "new"}, force=True).to_sql()
+        self.assertEqual(
+            sql,
+            """UPDATE "users" SET "name" = 'bill', "username" = 'new' WHERE "id" = '{}'""".format(
+                user.id
+            ),
+        )
+
+    def test_can_force_update_on_model(self):
+        user = UserForced.first()
+        sql = user.update({"name": user.name, "username": "new"}).to_sql()
+        self.assertEqual(
+            sql,
+            """UPDATE "users" SET "name" = 'bill', "username" = 'new' WHERE "id" = '{}'""".format(
+                user.id
+            ),
+        )
+
+    def test_force_update(self):
+        user = User.first()
+        sql = user.force_update({"name": user.name, "username": "new"}).to_sql()
+        self.assertEqual(
+            sql,
+            """UPDATE "users" SET "name" = 'bill', "username" = 'new' WHERE "id" = '{}'""".format(
+                user.id
+            ),
         )

--- a/tests/sqlite/models/test_sqlite_model.py
+++ b/tests/sqlite/models/test_sqlite_model.py
@@ -121,3 +121,8 @@ class BaseTestQueryRelationships(unittest.TestCase):
                 user.id
             ),
         )
+
+    def test_update_is_not_done_when_no_changes(self):
+        user = User.first()
+        sql = user.update({"name": user.name}).to_sql()
+        self.assertNotIn("UPDATE", sql)


### PR DESCRIPTION
When updating a record with `update()` method, if some attributes are given but have not changed, they will be added in the SQL `UPDATE` query. This can lead to some issues.

This PR changes the behaviour to remove unchanged attributes during the update and allow to force the old behaviour in 3 ways:
- with a `force=True` argument
```python
user.update({"email": "test@test.fr", "username": "Sam"}, force=True)
```
- There is also a new `force_update()` method on class/query builder that will always force the update with all the attributes given in argument:
```python
user.force_update({"email": "test@test.fr", "username": "Sam"})
```
- Finally a new attribute `__force_update__` attribute is available on model class that always enable forcing to avoid specifying it each time in `update()` method. The default value is `False`.
```python
class User(Model):
     __force_update__ = True
``` 