### PR TITLE
Cast from dict object to json field

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -54,7 +54,7 @@ class JsonCast:
     def get(self, value):
         if isinstance(value, dict):
             return value
-            
+
         return json.loads(value)
 
     def set(self, value):

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -52,6 +52,9 @@ class JsonCast:
     """Casts a value to JSON"""
 
     def get(self, value):
+        if isinstance(value, dict):
+            return value
+            
         return json.loads(value)
 
     def set(self, value):

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -78,6 +78,21 @@ class TestModels(unittest.TestCase):
         self.assertEqual(type(model.is_vip), bool)
         self.assertEqual(type(model.serialize()["is_vip"]), bool)
 
+    def test_model_can_cast_dict_attributes(self):
+        """test cast with dict object to json field"""
+        dictcasttest = {}
+        dictcasttest['key'] = 'value'
+        model = ModelTest.hydrate(
+            {"is_vip": 1, "payload": dictcasttest, "x": True, "f": "10.5"}
+        )
+
+        self.assertEqual(type(model.payload), dict)
+        self.assertEqual(type(model.x), int)
+        self.assertEqual(type(model.f), float)
+        self.assertEqual(type(model.is_vip), bool)
+        self.assertEqual(type(model.serialize()["is_vip"]), bool)
+
+
     def test_model_update_without_changes(self):
         model = ModelTest.hydrate(
             {"id": 1, "username": "joe", "name": "Joe", "admin": True}


### PR DESCRIPTION
Source of issue: https://github.com/MasoniteFramework/orm/issues/419   
#419 

When obtaining the object, the json field was already loaded as dict, however, JsonCast was forcing cast again.
To resolve this, a check has been added if the value is already dict. If true, return the value, otherwise, cast.

*first issue -> this is my first Pull Request 


![image](https://user-images.githubusercontent.com/56178491/114459876-789fef80-9bb7-11eb-86aa-6b95dbd7487f.png)

