### PR TITLE
Fixed adding primary key to altering a table

### DIFF
--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -150,8 +150,10 @@ class Blueprint:
             self
         """
         self._last_column = self.table.add_column(
-            column, "increments", nullable=nullable, primary=True
+            column, "increments", nullable=nullable
         )
+
+        self.primary(column)
         return self
 
     def tiny_increments(self, column, nullable=False):
@@ -167,8 +169,10 @@ class Blueprint:
             self
         """
         self._last_column = self.table.add_column(
-            column, "tiny_increments", nullable=nullable, primary=True
+            column, "tiny_increments", nullable=nullable
         )
+
+        self.primary(column)
         return self
 
     def uuid(self, column, nullable=False, length=36):
@@ -201,8 +205,10 @@ class Blueprint:
             self
         """
         self._last_column = self.table.add_column(
-            column, "big_increments", nullable=nullable, primary=True
+            column, "big_increments", nullable=nullable
         )
+
+        self.primary(column)
         return self
 
     def binary(self, column, nullable=False):

--- a/src/masoniteorm/schema/platforms/MSSQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MSSQLPlatform.py
@@ -176,6 +176,10 @@ class MSSQLPlatform(Platform):
                     )
                 elif constraint.constraint_type == "fulltext":
                     pass
+                elif constraint.constraint_type == "primary_key":
+                    sql.append(
+                        f"ALTER TABLE {self.wrap_table(table.name)} ADD CONSTRAINT {constraint.name} PRIMARY KEY ({','.join(constraint.columns)})"
+                    )
         return sql
 
     def add_column_string(self):

--- a/src/masoniteorm/schema/platforms/MySQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MySQLPlatform.py
@@ -267,6 +267,10 @@ class MySQLPlatform(Platform):
                     sql.append(
                         f"ALTER TABLE {self.wrap_table(table.name)} ADD FULLTEXT {constraint.name}({','.join(constraint.columns)})"
                     )
+                elif constraint.constraint_type == "primary_key":
+                    sql.append(
+                        f"ALTER TABLE {self.wrap_table(table.name)} ADD CONSTRAINT {constraint.name} PRIMARY KEY ({','.join(constraint.columns)})"
+                    )
 
         if table.removed_indexes:
             constraints = table.removed_indexes

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -279,11 +279,16 @@ class PostgresPlatform(Platform):
                     )
                 )
 
+        print(table.added_constraints)
         if table.added_constraints:
             for name, constraint in table.added_constraints.items():
                 if constraint.constraint_type == "unique":
                     sql.append(
                         f"ALTER TABLE {self.wrap_table(table.name)} ADD CONSTRAINT {constraint.name} UNIQUE({','.join(constraint.columns)})"
+                    )
+                if constraint.constraint_type == "primary_key":
+                    sql.append(
+                        f"ALTER TABLE {self.wrap_table(table.name)} ADD CONSTRAINT {constraint.name} PRIMARY KEY ({','.join(constraint.columns)})"
                     )
 
         return sql

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -261,13 +261,15 @@ class PostgresPlatform(Platform):
                     )
                 )
 
-        if table.dropped_foreign_keys or table.removed_indexes:
-            constraints = table.dropped_foreign_keys
-            constraints += table.removed_indexes
-            for constraint in constraints:
+        if table.dropped_foreign_keys:
+            for constraint in table.dropped_foreign_keys:
                 sql.append(
                     f"ALTER TABLE {self.wrap_table(table.name)} DROP CONSTRAINT {constraint}"
                 )
+
+        if table.removed_indexes:
+            for constraint in table.removed_indexes:
+                sql.append(f"DROP INDEX {constraint}")
 
         if table.added_indexes:
             for name, index in table.added_indexes.items():
@@ -279,7 +281,6 @@ class PostgresPlatform(Platform):
                     )
                 )
 
-        print(table.added_constraints)
         if table.added_constraints:
             for name, constraint in table.added_constraints.items():
                 if constraint.constraint_type == "unique":

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -286,7 +286,7 @@ class PostgresPlatform(Platform):
                     sql.append(
                         f"ALTER TABLE {self.wrap_table(table.name)} ADD CONSTRAINT {constraint.name} UNIQUE({','.join(constraint.columns)})"
                     )
-                if constraint.constraint_type == "primary_key":
+                elif constraint.constraint_type == "primary_key":
                     sql.append(
                         f"ALTER TABLE {self.wrap_table(table.name)} ADD CONSTRAINT {constraint.name} PRIMARY KEY ({','.join(constraint.columns)})"
                     )

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -261,15 +261,13 @@ class PostgresPlatform(Platform):
                     )
                 )
 
-        if table.dropped_foreign_keys:
-            for constraint in table.dropped_foreign_keys:
+        if table.dropped_foreign_keys or table.removed_indexes:
+            constraints = table.dropped_foreign_keys
+            constraints += table.removed_indexes
+            for constraint in constraints:
                 sql.append(
                     f"ALTER TABLE {self.wrap_table(table.name)} DROP CONSTRAINT {constraint}"
                 )
-
-        if table.removed_indexes:
-            for constraint in table.removed_indexes:
-                sql.append(f"DROP INDEX {constraint}")
 
         if table.added_indexes:
             for name, index in table.added_indexes.items():
@@ -281,6 +279,7 @@ class PostgresPlatform(Platform):
                     )
                 )
 
+        print(table.added_constraints)
         if table.added_constraints:
             for name, constraint in table.added_constraints.items():
                 if constraint.constraint_type == "unique":

--- a/src/masoniteorm/schema/platforms/SQLitePlatform.py
+++ b/src/masoniteorm/schema/platforms/SQLitePlatform.py
@@ -237,6 +237,10 @@ class SQLitePlatform(Platform):
                     sql.append(
                         f"CREATE UNIQUE INDEX {constraint.name} ON {self.wrap_table(diff.name)}({','.join(constraint.columns if isinstance(constraint.columns, list) else [constraint.columns])})"
                     )
+                elif constraint.constraint_type == "primary_key":
+                    sql.append(
+                        f"ALTER TABLE {self.wrap_table(diff.name)} ADD CONSTRAINT {constraint.name} PRIMARY KEY ({','.join(constraint.columns)})"
+                    )
 
         return sql
 

--- a/tests/mssql/schema/test_mssql_schema_builder.py
+++ b/tests/mssql/schema/test_mssql_schema_builder.py
@@ -92,10 +92,10 @@ class TestMSSQLSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             (
-                "CREATE TABLE [users] ([id] INT IDENTITY NOT NULL PRIMARY KEY, [name] VARCHAR(255) NOT NULL, [email] VARCHAR(255) NOT NULL, "
+                "CREATE TABLE [users] ([id] INT IDENTITY NOT NULL, [name] VARCHAR(255) NOT NULL, [email] VARCHAR(255) NOT NULL, "
                 "[password] VARCHAR(255) NOT NULL, [admin] INT NOT NULL DEFAULT 0, [remember_token] VARCHAR(255) NULL, "
                 "[verified_at] DATETIME NULL DEFAULT CURRENT_TIMESTAMP, [created_at] DATETIME NULL DEFAULT CURRENT_TIMESTAMP, "
-                "[updated_at] DATETIME NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_email_unique UNIQUE (email))"
+                "[updated_at] DATETIME NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), CONSTRAINT users_email_unique UNIQUE (email))"
             ),
         )
 
@@ -123,10 +123,10 @@ class TestMSSQLSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             (
-                "CREATE TABLE [users] ([id] INT IDENTITY NOT NULL PRIMARY KEY, [gender] VARCHAR(255) NOT NULL CHECK([gender] IN ('male', 'female')), [name] VARCHAR(255) NOT NULL, [duration] VARCHAR(255) NOT NULL, "
+                "CREATE TABLE [users] ([id] INT IDENTITY NOT NULL, [gender] VARCHAR(255) NOT NULL CHECK([gender] IN ('male', 'female')), [name] VARCHAR(255) NOT NULL, [duration] VARCHAR(255) NOT NULL, "
                 "[url] VARCHAR(255) NOT NULL, [last_address] VARCHAR(255) NULL, [route_origin] VARCHAR(255) NULL, [mac_address] VARCHAR(255) NULL, [published_at] DATETIME NOT NULL, [thumbnail] VARCHAR(255) NULL, [premium] INT NOT NULL, "
                 "[author_id] INT NULL, [description] TEXT NOT NULL, [created_at] DATETIME NULL DEFAULT CURRENT_TIMESTAMP, "
-                "[updated_at] DATETIME NULL DEFAULT CURRENT_TIMESTAMP, "
+                "[updated_at] DATETIME NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), "
                 "CONSTRAINT users_author_id_foreign FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE)"
             ),
         )

--- a/tests/mssql/schema/test_mssql_schema_builder_alter.py
+++ b/tests/mssql/schema/test_mssql_schema_builder_alter.py
@@ -129,6 +129,16 @@ class TestMySQLSchemaBuilderAlter(unittest.TestCase):
 
         self.assertEqual(blueprint.to_sql(), sql)
 
+    def test_alter_add_primary(self):
+        with self.schema.table("users") as blueprint:
+            blueprint.primary("playlist_id")
+
+        sql = [
+            "ALTER TABLE [users] ADD CONSTRAINT users_playlist_id_primary PRIMARY KEY (playlist_id)"
+        ]
+
+        self.assertEqual(blueprint.to_sql(), sql)
+
     def test_alter_add_index(self):
         with self.schema.table("users") as blueprint:
             blueprint.index("playlist_id")

--- a/tests/mysql/grammar/test_mysql_qmark.py
+++ b/tests/mysql/grammar/test_mysql_qmark.py
@@ -64,7 +64,6 @@ class BaseQMarkTest:
         self.assertEqual(mark._bindings, bindings)
 
 
-
 class TestMySQLQmark(BaseQMarkTest, unittest.TestCase):
     def can_compile_select(self):
         """

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -95,11 +95,11 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             (
-                "CREATE TABLE `users` (`id` INT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY, "
+                "CREATE TABLE `users` (`id` INT UNSIGNED AUTO_INCREMENT NOT NULL, "
                 "`name` VARCHAR(255) NOT NULL, `active` TINYINT(1) NOT NULL, `email` VARCHAR(255) NOT NULL, `gender` ENUM('male', 'female') NOT NULL, "
                 "`password` VARCHAR(255) NOT NULL, `money` DECIMAL(17, 6) NOT NULL, "
                 "`admin` INT(11) NOT NULL DEFAULT 0, `option` VARCHAR(255) NOT NULL DEFAULT 'ADMIN', `remember_token` VARCHAR(255) NULL, `verified_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
-                "`created_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_email_unique UNIQUE (email))"
+                "`created_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), CONSTRAINT users_email_unique UNIQUE (email))"
             ),
         )
 
@@ -141,11 +141,11 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             (
-                "CREATE TABLE `users` (`id` BIGINT UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY, `name` VARCHAR(255) NOT NULL, "
+                "CREATE TABLE `users` (`id` BIGINT UNSIGNED AUTO_INCREMENT NOT NULL, `name` VARCHAR(255) NOT NULL, "
                 "`duration` VARCHAR(255) NOT NULL, `url` VARCHAR(255) NOT NULL, `last_address` VARCHAR(255) NULL, `route_origin` VARCHAR(255) NULL, `mac_address` VARCHAR(255) NULL, "
                 "`published_at` DATETIME NOT NULL, `thumbnail` VARCHAR(255) NULL, "
                 "`premium` INT(11) NOT NULL, `author_id` INT UNSIGNED NULL, `description` TEXT NOT NULL, `created_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
-                "`updated_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_author_id_foreign FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE)"
+                "`updated_at` TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), CONSTRAINT users_author_id_foreign FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE CASCADE)"
             ),
         )
 

--- a/tests/mysql/schema/test_mysql_schema_builder_alter.py
+++ b/tests/mysql/schema/test_mysql_schema_builder_alter.py
@@ -124,6 +124,16 @@ class TestMySQLSchemaBuilderAlter(unittest.TestCase):
 
         self.assertEqual(blueprint.to_sql(), sql)
 
+    def test_alter_add_primary(self):
+        with self.schema.table("users") as blueprint:
+            blueprint.primary("playlist_id")
+
+        sql = [
+            "ALTER TABLE `users` ADD CONSTRAINT users_playlist_id_primary PRIMARY KEY (playlist_id)"
+        ]
+
+        self.assertEqual(blueprint.to_sql(), sql)
+
     def test_alter_drop_index_shortcut(self):
         with self.schema.table("users") as blueprint:
             blueprint.drop_index(["playlist_id"])

--- a/tests/postgres/schema/test_postgres_schema_builder.py
+++ b/tests/postgres/schema/test_postgres_schema_builder.py
@@ -99,10 +99,11 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             (
-                'CREATE TABLE "users" (id SERIAL UNIQUE NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL, '
+                'CREATE TABLE "users" (id SERIAL UNIQUE NOT NULL, name VARCHAR(255) NOT NULL, '
                 "email VARCHAR(255) NOT NULL, password VARCHAR(255) NOT NULL, admin INTEGER NOT NULL DEFAULT 0, "
                 "remember_token VARCHAR(255) NULL, verified_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
                 "created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
+                "CONSTRAINT users_id_primary PRIMARY KEY (id), "
                 "CONSTRAINT users_email_unique UNIQUE (email))"
             ),
         )
@@ -135,11 +136,11 @@ class TestPostgresSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             (
-                """CREATE TABLE "users" (id BIGSERIAL UNIQUE NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL, gender VARCHAR(255) CHECK(gender IN ('male', 'female')) NOT NULL, """
+                """CREATE TABLE "users" (id BIGSERIAL UNIQUE NOT NULL, name VARCHAR(255) NOT NULL, gender VARCHAR(255) CHECK(gender IN ('male', 'female')) NOT NULL, """
                 "duration VARCHAR(255) NOT NULL, money DECIMAL(17, 6) NOT NULL, url VARCHAR(255) NOT NULL, option VARCHAR(255) NOT NULL DEFAULT 'ADMIN', payload JSONB NOT NULL, last_address INET NULL, "
                 "route_origin CIDR NULL, mac_address MACADDR NULL, published_at TIMESTAMP NOT NULL, thumbnail VARCHAR(255) NULL, premium INTEGER NOT NULL, amount DOUBLE PRECISION NOT NULL DEFAULT 0.0, "
                 "author_id INT NULL, description TEXT NOT NULL, created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
-                "updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
+                "updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), "
                 "CONSTRAINT users_author_id_foreign FOREIGN KEY (author_id) REFERENCES authors(id) ON DELETE CASCADE)"
             ),
         )

--- a/tests/postgres/schema/test_postgres_schema_builder_alter.py
+++ b/tests/postgres/schema/test_postgres_schema_builder_alter.py
@@ -139,7 +139,9 @@ class TestPostgresSchemaBuilderAlter(unittest.TestCase):
         with self.schema.table("users") as blueprint:
             blueprint.primary("playlist_id")
 
-        sql = ['ALTER TABLE "users" ADD CONSTRAINT users_playlist_id_primary PRIMARY KEY (playlist_id)']
+        sql = [
+            'ALTER TABLE "users" ADD CONSTRAINT users_playlist_id_primary PRIMARY KEY (playlist_id)'
+        ]
 
         self.assertEqual(blueprint.to_sql(), sql)
 

--- a/tests/postgres/schema/test_postgres_schema_builder_alter.py
+++ b/tests/postgres/schema/test_postgres_schema_builder_alter.py
@@ -135,6 +135,14 @@ class TestPostgresSchemaBuilderAlter(unittest.TestCase):
 
         self.assertEqual(blueprint.to_sql(), sql)
 
+    def test_alter_add_primary(self):
+        with self.schema.table("users") as blueprint:
+            blueprint.primary("playlist_id")
+
+        sql = ['ALTER TABLE "users" ADD CONSTRAINT users_playlist_id_primary PRIMARY KEY (playlist_id)']
+
+        self.assertEqual(blueprint.to_sql(), sql)
+
     def test_alter_drop_index(self):
         with self.schema.table("users") as blueprint:
             blueprint.drop_index("users_playlist_id_index")

--- a/tests/sqlite/schema/test_sqlite_schema_builder.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder.py
@@ -108,10 +108,10 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             (
-                """CREATE TABLE "users" (id INTEGER NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL, gender VARCHAR(255) CHECK(gender IN ('male', 'female')) NOT NULL, email VARCHAR(255) NOT NULL, """
+                """CREATE TABLE "users" (id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, gender VARCHAR(255) CHECK(gender IN ('male', 'female')) NOT NULL, email VARCHAR(255) NOT NULL, """
                 "password VARCHAR(255) NOT NULL, option VARCHAR(255) NOT NULL DEFAULT 'ADMIN', admin INTEGER NOT NULL DEFAULT 0, remember_token VARCHAR(255) NULL, "
                 "verified_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
-                "updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, UNIQUE(email), UNIQUE(email, name))"
+                "updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), UNIQUE(email), UNIQUE(email, name))"
             ),
         )
 
@@ -213,10 +213,10 @@ class TestSQLiteSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             (
-                'CREATE TABLE "users" (id BIGINT NOT NULL PRIMARY KEY, name VARCHAR(255) NOT NULL, duration VARCHAR(255) NOT NULL, '
+                'CREATE TABLE "users" (id BIGINT NOT NULL, name VARCHAR(255) NOT NULL, duration VARCHAR(255) NOT NULL, '
                 "url VARCHAR(255) NOT NULL, payload JSON NOT NULL, birth VARCHAR(4) NOT NULL, last_address VARCHAR(255) NULL, route_origin VARCHAR(255) NULL, mac_address VARCHAR(255) NULL, "
                 "published_at DATETIME NOT NULL, wakeup_at TIME NOT NULL, thumbnail VARCHAR(255) NULL, premium INTEGER NOT NULL, author_id UNSIGNED INT NULL, description TEXT NOT NULL, "
-                "created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, "
+                "created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), "
                 "CONSTRAINT users_author_id_foreign FOREIGN KEY (author_id) REFERENCES users(id) ON DELETE SET NULL)"
             ),
         )

--- a/tests/sqlite/schema/test_sqlite_schema_builder_alter.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder_alter.py
@@ -144,6 +144,16 @@ class TestSQLiteSchemaBuilderAlter(unittest.TestCase):
         with schema.table("table_schema") as blueprint:
             blueprint.string("name").nullable()
 
+    def test_alter_add_primary(self):
+        with self.schema.table("users") as blueprint:
+            blueprint.primary("playlist_id")
+
+        sql = [
+            'ALTER TABLE "users" ADD CONSTRAINT users_playlist_id_primary PRIMARY KEY (playlist_id)'
+        ]
+
+        self.assertEqual(blueprint.to_sql(), sql)
+
     def test_alter_add_column_and_foreign_key(self):
         with self.schema.table("users") as blueprint:
             blueprint.unsigned_integer("playlist_id").nullable()


### PR DESCRIPTION
Closes #460 

This PR fixes an issue where adding a primary key to an alter statement would not work.

This PR also changes primary keys from a column constraint to a table constraint. This way we can specify the primary key constraint name. This will support a new drop_primary method on the blueprint class down the road