### PR TITLE
Feature/464

### DIFF
--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -537,12 +537,6 @@ class QueryBuilder(ObservesEvents):
         """
         operator, value = self._extract_operator_value(*args)
 
-        if value is None:
-            value = ""
-        elif value is True:
-            value = "1"
-        elif value is False:
-            value = "0"
 
         if inspect.isfunction(column):
             builder = column(self.new())
@@ -551,6 +545,7 @@ class QueryBuilder(ObservesEvents):
             )
         elif isinstance(column, dict):
             for key, value in column.items():
+
                 self._wheres += ((QueryExpression(key, "=", value, "value")),)
         elif isinstance(value, QueryBuilder):
             self._wheres += (

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -537,7 +537,6 @@ class QueryBuilder(ObservesEvents):
         """
         operator, value = self._extract_operator_value(*args)
 
-
         if inspect.isfunction(column):
             builder = column(self.new())
             self._wheres += (

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -619,6 +619,12 @@ class BaseGrammar:
                             value=val, separator=","
                         )
                 query_value = query_value.rstrip(",").rstrip(", ") + ")"
+            elif value is True and value_type != 'NOT NULL':
+                sql_string = self.get_true_column_string()
+                query_value = 1
+            elif value is False and value_type != 'NOT NULL':
+                sql_string = self.get_false_column_string()
+                query_value = 0
             elif qmark and value_type != "column":
                 query_value = "'?'"
                 if (
@@ -649,6 +655,12 @@ class BaseGrammar:
             loop_count += 1
 
         return sql
+
+    def get_true_column_string(self):
+        return "{keyword} {column} = '1'"
+
+    def get_false_column_string(self):
+        return "{keyword} {column} = '0'"
 
     def add_binding(self, binding):
         """Adds a binding to the bindings tuple.

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -619,10 +619,10 @@ class BaseGrammar:
                             value=val, separator=","
                         )
                 query_value = query_value.rstrip(",").rstrip(", ") + ")"
-            elif value is True and value_type != 'NOT NULL':
+            elif value is True and value_type != "NOT NULL":
                 sql_string = self.get_true_column_string()
                 query_value = 1
-            elif value is False and value_type != 'NOT NULL':
+            elif value is False and value_type != "NOT NULL":
                 sql_string = self.get_false_column_string()
                 query_value = 0
             elif qmark and value_type != "column":

--- a/src/masoniteorm/query/grammars/MySQLGrammar.py
+++ b/src/masoniteorm/query/grammars/MySQLGrammar.py
@@ -94,6 +94,12 @@ class MySQLGrammar(BaseGrammar):
     def where_not_like_string(self):
         return "{keyword} {column} NOT LIKE {value}"
 
+    def get_true_column_string(self):
+        return "{keyword} {column} = '1'"
+
+    def get_false_column_string(self):
+        return "{keyword} {column} = '0'"
+
     def process_table(self, table):
         """Compiles a given table name.
 

--- a/src/masoniteorm/query/grammars/PostgresGrammar.py
+++ b/src/masoniteorm/query/grammars/PostgresGrammar.py
@@ -55,6 +55,12 @@ class PostgresGrammar(BaseGrammar):
     def aggregate_string_without_alias(self):
         return "{aggregate_function}({column})"
 
+    def get_true_column_string(self):
+        return "{keyword} {column} IS True"
+
+    def get_false_column_string(self):
+        return "{keyword} {column} IS False"
+
     def subquery_string(self):
         return "({query})"
 

--- a/src/masoniteorm/query/grammars/SQLiteGrammar.py
+++ b/src/masoniteorm/query/grammars/SQLiteGrammar.py
@@ -186,6 +186,12 @@ class SQLiteGrammar(BaseGrammar):
     def disable_foreign_key_constraints(self):
         return "PRAGMA foreign_keys = OFF"
 
+    def get_true_column_string(self):
+        return "{keyword} {column} = '1'"
+
+    def get_false_column_string(self):
+        return "{keyword} {column} = '0'"
+
     def truncate_table(self, table, foreign_keys=False):
         # SQLite do not have TRUNCATE TABLE command but we can
         # use SQLite DELETE command to delete complete data from an existing table

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -131,7 +131,7 @@ class TestModels(unittest.TestCase):
 
         self.assertEqual(
             sql,
-            """SELECT * FROM `model_tests` WHERE `model_tests`.`name` = 'joe' OR `model_tests`.`is_vip` = 'True'""",
+            """SELECT * FROM `model_tests` WHERE `model_tests`.`name` = 'joe' OR `model_tests`.`is_vip` = '1'""",
         )
 
     def test_model_using_or_where_and_chaining_wheres(self):

--- a/tests/mysql/grammar/test_mysql_qmark.py
+++ b/tests/mysql/grammar/test_mysql_qmark.py
@@ -63,6 +63,24 @@ class BaseQMarkTest:
         self.assertEqual(mark.to_qmark(), sql)
         self.assertEqual(mark._bindings, bindings)
 
+    def test_can_compile_where_with_true_value(self):
+        mark = self.builder.where("is_admin", True)
+
+        sql, bindings = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(mark.to_qmark(), sql)
+        self.assertEqual(mark._bindings, bindings)
+
+    def test_can_compile_where_with_false_value(self):
+        mark = self.builder.where("is_admin", False)
+
+        sql, bindings = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(mark.to_qmark(), sql)
+        self.assertEqual(mark._bindings, bindings)
+
 
 class TestMySQLQmark(BaseQMarkTest, unittest.TestCase):
     def can_compile_select(self):
@@ -111,3 +129,15 @@ class TestMySQLQmark(BaseQMarkTest, unittest.TestCase):
         self.builder.where_not_null("id").to_qmark()
         """
         return ("SELECT * FROM `users` WHERE `users`.`name` = '?'", [0])
+
+    def can_compile_where_with_true_value(self):
+        """
+        self.builder.where("is_admin", True).to_qmark()
+        """
+        return ("SELECT * FROM `users` WHERE `users`.`is_admin` = '1'", [])
+
+    def can_compile_where_with_false_value(self):
+        """
+        self.builder.where("is_admin", True).to_qmark()
+        """
+        return ("SELECT * FROM `users` WHERE `users`.`is_admin` = '0'", [])

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -280,7 +280,7 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         builder = self.get_builder()
         builder.where("is_admin", "=", True).first_or_fail()
         """
-        return """SELECT * FROM "users" WHERE "users"."is_admin" = '1' LIMIT 1"""
+        return """SELECT * FROM "users" WHERE "users"."is_admin" IS True LIMIT 1"""
 
     def where_not_like(self):
         """


### PR DESCRIPTION
Closes #464 

This PR fixes an issue where you could not specify a boolean in a where condition:

```python
where('is_admin', True)
```

For Postgres it will do a `WHERE {column} IS True` because Postgres has an actual boolean column. Every other database it will just do `WHERE {column} = '1'`