### PR TITLE
fixed pivot serializing

### DIFF
--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -303,13 +303,13 @@ class Collection:
     def reverse(self):
         self._items = self[::-1]
 
-    def serialize(self):
+    def serialize(self, *args, **kwargs):
         def _serialize(item):
             if self.__appends__:
                 item.set_appends(self.__appends__)
 
             if hasattr(item, "serialize"):
-                return item.serialize()
+                return item.serialize(*args, **kwargs)
             elif hasattr(item, "to_dict"):
                 return item.to_dict()
             return item

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -449,6 +449,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         """
         serialized_dictionary = self.__attributes__
 
+
         # prevent using both hidden and visible at the same time
         if self.__visible__ and self.__hidden__:
             raise AttributeError(
@@ -484,10 +485,13 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         # Serialize relationships as well
         serialized_dictionary.update(self.relations_to_dict())
+
         for append in self.__appends__:
             serialized_dictionary.update({append: getattr(self, append)})
 
         for key, value in serialized_dictionary.items():
+            if hasattr(value, 'serialize'):
+                value = value.serialize()
             if isinstance(value, datetime):
                 value = self.get_new_serialized_date(value)
             if key in self.__casts__:
@@ -531,6 +535,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
                 if value is None:
                     new_dic.update({key: {}})
                     continue
+                    
                 new_dic.update({key: value.serialize()})
 
         return new_dic

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -1,6 +1,5 @@
 import json
 from datetime import datetime, date as datetimedate, time as datetimetime
-from os import remove
 
 from inflection import tableize
 import inspect

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -717,7 +717,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         if key in self.__attributes__:
             del self.__attributes__[key]
             return True
-        
+
         return False
 
     def get_dirty_attributes(self):

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -713,6 +713,13 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         return attributes
 
+    def delete_attribute(self, key):
+        if key in self.__attributes__:
+            del self.__attributes__[key]
+            return True
+        
+        return False
+
     def get_dirty_attributes(self):
         if "builder" in self.__dirty_attributes__:
             self.__dirty_attributes__.pop("builder")

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -449,7 +449,6 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         """
         serialized_dictionary = self.__attributes__
 
-
         # prevent using both hidden and visible at the same time
         if self.__visible__ and self.__hidden__:
             raise AttributeError(
@@ -490,7 +489,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             serialized_dictionary.update({append: getattr(self, append)})
 
         for key, value in serialized_dictionary.items():
-            if hasattr(value, 'serialize'):
+            if hasattr(value, "serialize"):
                 value = value.serialize()
             if isinstance(value, datetime):
                 value = self.get_new_serialized_date(value)
@@ -535,7 +534,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
                 if value is None:
                     new_dic.update({key: {}})
                     continue
-                    
+
                 new_dic.update({key: value.serialize()})
 
         return new_dic

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -498,7 +498,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             if key in self.__hidden__:
                 remove_keys.append(key)
             if hasattr(value, "serialize"):
-                value = value.serialize(['pivot'])
+                value = value.serialize(["pivot"])
             if isinstance(value, datetime):
                 value = self.get_new_serialized_date(value)
             if key in self.__casts__:
@@ -546,7 +546,13 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
                     new_dic.update({key: {}})
                     continue
 
-                new_dic.update({key: value.serialize(exclude=self.__relationship_hidden__.get(key, []))})
+                new_dic.update(
+                    {
+                        key: value.serialize(
+                            exclude=self.__relationship_hidden__.get(key, [])
+                        )
+                    }
+                )
 
         return new_dic
 

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -111,7 +111,6 @@ class BelongsToMany(BaseRelationship):
 
         result = result.get()
 
-        # print(result.serialize())
         for p in result:
             pivot_data = {
                 self.local_foreign_key: getattr(p, self.local_foreign_key),

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -18,6 +18,7 @@ class BelongsToMany(BaseRelationship):
         with_timestamps=False,
         pivot_id="id",
         attribute="pivot",
+        extra_fields=[]
     ):
         if isinstance(fn, str):
             self.fn = None
@@ -36,6 +37,7 @@ class BelongsToMany(BaseRelationship):
         self.with_timestamps = with_timestamps
         self._as = attribute
         self.pivot_id = pivot_id
+        self.extra_fields = extra_fields
 
     def set_keys(self, owner, attribute):
         self.local_foreign_key = self.local_foreign_key or "id"
@@ -103,8 +105,13 @@ class BelongsToMany(BaseRelationship):
                 f"{table1}.{self.local_owner_key}", getattr(owner, self.local_owner_key)
             )
 
+        if self.extra_fields:
+            for field in self.extra_fields:
+                result.select(f"{self._table}.{field}")
+
         result = result.get()
 
+        # print(result.serialize())
         for p in result:
             pivot_data = {
                 self.local_foreign_key: getattr(p, self.local_foreign_key),
@@ -121,6 +128,11 @@ class BelongsToMany(BaseRelationship):
                         "created_at": getattr(p, "created_at"),
                     }
                 )
+
+            if self.extra_fields:
+                for field in self.extra_fields:
+                    pivot_data.update({field: getattr(p, field)})
+                    p.delete_attribute(field)
 
             setattr(
                 p,
@@ -163,6 +175,10 @@ class BelongsToMany(BaseRelationship):
             f"{self._table}.{self.local_foreign_key}",
             f"{self._table}.{self.other_foreign_key}",
         ).table(f"{table1}")
+
+        if self.extra_fields:
+            for field in self.extra_fields:
+                result.select(f"{self._table}.{field}")
 
         result.join(
             f"{self._table}",
@@ -213,6 +229,11 @@ class BelongsToMany(BaseRelationship):
 
             if self.pivot_id:
                 pivot_data.update({self.pivot_id: getattr(model, self.pivot_id)})
+            
+            if self.extra_fields:
+                for field in self.extra_fields:
+                    pivot_data.update({field: getattr(model, field)})
+                    model.delete_attribute(field)
 
             setattr(
                 model,

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -23,7 +23,7 @@ class BelongsToMany(BaseRelationship):
             self.fn = None
             self.local_foreign_key = fn
             self.other_foreign_key = local_foreign_key
-            self.local_owner_key = other_foreign_key
+            self.local_owner_key = other_foreign_key or "id"
             self.other_owner_key = local_owner_key or "id"
         else:
             self.fn = fn
@@ -97,7 +97,7 @@ class BelongsToMany(BaseRelationship):
             "=",
             f"{table2}.{self.other_owner_key}",
         )
-
+        print('zzz', self.local_owner_key)
         if hasattr(owner, self.local_owner_key):
             result.where(
                 f"{table1}.{self.local_owner_key}", getattr(owner, self.local_owner_key)

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -121,7 +121,7 @@ class BelongsToMany(BaseRelationship):
                         "created_at": getattr(p, "created_at"),
                     }
                 )
-            
+
             setattr(
                 p,
                 self._as,
@@ -202,7 +202,6 @@ class BelongsToMany(BaseRelationship):
                 self.local_foreign_key: getattr(model, self.local_foreign_key),
                 self.other_foreign_key: getattr(model, self.other_foreign_key),
             }
-
 
             if self.with_timestamps:
                 pivot_data.update(

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -97,7 +97,7 @@ class BelongsToMany(BaseRelationship):
             "=",
             f"{table2}.{self.other_owner_key}",
         )
-        print('zzz', self.local_owner_key)
+        print("zzz", self.local_owner_key)
         if hasattr(owner, self.local_owner_key):
             result.where(
                 f"{table1}.{self.local_owner_key}", getattr(owner, self.local_owner_key)

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -18,7 +18,7 @@ class BelongsToMany(BaseRelationship):
         with_timestamps=False,
         pivot_id="id",
         attribute="pivot",
-        extra_fields=[]
+        extra_fields=[],
     ):
         if isinstance(fn, str):
             self.fn = None
@@ -229,7 +229,7 @@ class BelongsToMany(BaseRelationship):
 
             if self.pivot_id:
                 pivot_data.update({self.pivot_id: getattr(model, self.pivot_id)})
-            
+
             if self.extra_fields:
                 for field in self.extra_fields:
                     pivot_data.update({field: getattr(model, field)})

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -77,12 +77,12 @@ class BelongsToMany(BaseRelationship):
         ).table(f"{table1}")
 
         if self.pivot_id:
-            result.select(f"{self._table}.id as m_reserved_3")
+            result.select(f"{self._table}.{self.pivot_id} as {self.pivot_id}")
 
         if self.with_timestamps:
             result.select(
-                f"{self._table}.updated_at as m_reserved_1",
-                f"{self._table}.created_at as m_reserved_2",
+                f"{self._table}.updated_at as updated_at",
+                f"{self._table}.created_at as created_at",
             )
 
         result.join(
@@ -97,7 +97,7 @@ class BelongsToMany(BaseRelationship):
             "=",
             f"{table2}.{self.other_owner_key}",
         )
-        print("zzz", self.local_owner_key)
+
         if hasattr(owner, self.local_owner_key):
             result.where(
                 f"{table1}.{self.local_owner_key}", getattr(owner, self.local_owner_key)
@@ -112,15 +112,16 @@ class BelongsToMany(BaseRelationship):
             }
 
             if self.pivot_id:
-                pivot_data.update({self.pivot_id: getattr(p, "m_reserved_3")})
+                pivot_data.update({self.pivot_id: getattr(p, self.pivot_id)})
 
             if self.with_timestamps:
                 pivot_data.update(
                     {
-                        "updated_at": getattr(p, "m_reserved_1"),
-                        "created_at": getattr(p, "m_reserved_2"),
+                        "updated_at": getattr(p, "updated_at"),
+                        "created_at": getattr(p, "created_at"),
                     }
                 )
+            
             setattr(
                 p,
                 self._as,
@@ -179,12 +180,12 @@ class BelongsToMany(BaseRelationship):
 
         if self.with_timestamps:
             result.select(
-                f"{self._table}.updated_at as m_reserved_1",
-                f"{self._table}.created_at as m_reserved_2",
+                f"{self._table}.updated_at as updated_at",
+                f"{self._table}.created_at as created_at",
             )
 
         if self.pivot_id:
-            result.select(f"{self._table}.id as m_reserved_3")
+            result.select(f"{self._table}.{self.pivot_id} as {self.pivot_id}")
 
         if isinstance(relation, Collection):
             final_result = result.where_in(
@@ -202,16 +203,17 @@ class BelongsToMany(BaseRelationship):
                 self.other_foreign_key: getattr(model, self.other_foreign_key),
             }
 
+
             if self.with_timestamps:
                 pivot_data.update(
                     {
-                        "updated_at": getattr(p, "m_reserved_1"),
-                        "created_at": getattr(p, "m_reserved_2"),
+                        "updated_at": getattr(model, "updated_at"),
+                        "created_at": getattr(model, "created_at"),
                     }
                 )
 
             if self.pivot_id:
-                pivot_data.update({self.pivot_id: getattr(model, "m_reserved_3")})
+                pivot_data.update({self.pivot_id: getattr(model, self.pivot_id)})
 
             setattr(
                 model,

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -18,7 +18,7 @@ class BelongsToMany(BaseRelationship):
         with_timestamps=False,
         pivot_id="id",
         attribute="pivot",
-        extra_fields=[],
+        with_fields=[],
     ):
         if isinstance(fn, str):
             self.fn = None
@@ -37,7 +37,7 @@ class BelongsToMany(BaseRelationship):
         self.with_timestamps = with_timestamps
         self._as = attribute
         self.pivot_id = pivot_id
-        self.extra_fields = extra_fields
+        self.with_fields = with_fields
 
     def set_keys(self, owner, attribute):
         self.local_foreign_key = self.local_foreign_key or "id"
@@ -105,8 +105,8 @@ class BelongsToMany(BaseRelationship):
                 f"{table1}.{self.local_owner_key}", getattr(owner, self.local_owner_key)
             )
 
-        if self.extra_fields:
-            for field in self.extra_fields:
+        if self.with_fields:
+            for field in self.with_fields:
                 result.select(f"{self._table}.{field}")
 
         result = result.get()
@@ -129,8 +129,8 @@ class BelongsToMany(BaseRelationship):
                     }
                 )
 
-            if self.extra_fields:
-                for field in self.extra_fields:
+            if self.with_fields:
+                for field in self.with_fields:
                     pivot_data.update({field: getattr(p, field)})
                     p.delete_attribute(field)
 
@@ -176,8 +176,8 @@ class BelongsToMany(BaseRelationship):
             f"{self._table}.{self.other_foreign_key}",
         ).table(f"{table1}")
 
-        if self.extra_fields:
-            for field in self.extra_fields:
+        if self.with_fields:
+            for field in self.with_fields:
                 result.select(f"{self._table}.{field}")
 
         result.join(
@@ -230,8 +230,8 @@ class BelongsToMany(BaseRelationship):
             if self.pivot_id:
                 pivot_data.update({self.pivot_id: getattr(model, self.pivot_id)})
 
-            if self.extra_fields:
-                for field in self.extra_fields:
+            if self.with_fields:
+                for field in self.with_fields:
                     pivot_data.update({field: getattr(model, field)})
                     model.delete_attribute(field)
 


### PR DESCRIPTION
Need to work through a little bit more of this ..

The first thing is we need to hide relationship data somehow. For example, apart of the pivot information you have access to the pivot data 

<img width="851" alt="Screen Shot 2021-06-15 at 11 18 56 PM" src="https://user-images.githubusercontent.com/20172538/122153763-9f85d680-ce31-11eb-8d2b-0f861d833944.png">

I feel you may or may not want to return this data. For example, to an API response.

To solve this i added a new property:

```python
__relationship_hidden__ = {"people": ['pivot']}
```

This hides the `pivot` key from the `people` pivot table serialization

This PR also fixes a few issues i found with the belongs to many relationship

