### PR TITLE
fixed issue for mysql not saving unique constraint

### DIFF
--- a/src/masoniteorm/schema/platforms/MSSQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MSSQLPlatform.py
@@ -284,7 +284,7 @@ class MSSQLPlatform(Platform):
         return "CONSTRAINT {constraint_name} PRIMARY KEY ({columns})"
 
     def get_unique_constraint_string(self):
-        return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"
+        return "CONSTRAINT {constraint_name} UNIQUE ({columns})"
 
     def compile_table_exists(self, table, database):
         return f"SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{table}'"

--- a/src/masoniteorm/schema/platforms/MySQLPlatform.py
+++ b/src/masoniteorm/schema/platforms/MySQLPlatform.py
@@ -341,7 +341,7 @@ class MySQLPlatform(Platform):
         return "CONSTRAINT {constraint_name} PRIMARY KEY ({columns})"
 
     def get_unique_constraint_string(self):
-        return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"
+        return "CONSTRAINT {constraint_name} UNIQUE ({columns})"
 
     def compile_table_exists(self, table, database):
         return f"SELECT * from information_schema.tables where table_name='{table}' AND table_schema = '{database}'"

--- a/src/masoniteorm/schema/platforms/PostgresPlatform.py
+++ b/src/masoniteorm/schema/platforms/PostgresPlatform.py
@@ -348,7 +348,7 @@ class PostgresPlatform(Platform):
         return "CONSTRAINT {constraint_name} PRIMARY KEY ({columns})"
 
     def get_unique_constraint_string(self):
-        return "CONSTRAINT {table}_{name_columns}_unique UNIQUE ({columns})"
+        return "CONSTRAINT {constraint_name} UNIQUE ({columns})"
 
     def get_table_string(self):
         return '"{table}"'

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -36,13 +36,14 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
         with self.schema.create("users") as blueprint:
             blueprint.string("name")
             blueprint.integer("age")
-            blueprint.unique("name")
+            blueprint.unique("name"),
+            blueprint.unique("name", name="table_unique"),
 
         self.assertEqual(len(blueprint.table.added_columns), 2)
         self.assertEqual(
             blueprint.to_sql(),
             [
-                "CREATE TABLE `users` (`name` VARCHAR(255) NOT NULL, `age` INT(11) NOT NULL, CONSTRAINT users_name_unique UNIQUE (name))"
+                "CREATE TABLE `users` (`name` VARCHAR(255) NOT NULL, `age` INT(11) NOT NULL, CONSTRAINT users_name_unique UNIQUE (name), CONSTRAINT table_unique UNIQUE (name))"
             ],
         )
 

--- a/tests/mysql/schema/test_mysql_schema_builder_alter.py
+++ b/tests/mysql/schema/test_mysql_schema_builder_alter.py
@@ -213,6 +213,7 @@ class TestMySQLSchemaBuilderAlter(unittest.TestCase):
             blueprint.index("name")
             blueprint.index(["name", "email"])
             blueprint.unique("name")
+            blueprint.unique("name", name="table_unique")
             blueprint.unique(["name", "email"])
             blueprint.fulltext("description")
 
@@ -224,6 +225,7 @@ class TestMySQLSchemaBuilderAlter(unittest.TestCase):
                 "CREATE INDEX users_name_index ON `users`(name)",
                 "CREATE INDEX users_name_email_index ON `users`(name,email)",
                 "ALTER TABLE `users` ADD CONSTRAINT UNIQUE INDEX users_name_unique(name)",
+                "ALTER TABLE `users` ADD CONSTRAINT UNIQUE INDEX table_unique(name)",
                 "ALTER TABLE `users` ADD CONSTRAINT UNIQUE INDEX users_name_email_unique(name,email)",
                 "ALTER TABLE `users` ADD FULLTEXT description_fulltext(description)",
             ],

--- a/tests/sqlite/schema/test_sqlite_schema_builder_alter.py
+++ b/tests/sqlite/schema/test_sqlite_schema_builder_alter.py
@@ -34,6 +34,16 @@ class TestSQLiteSchemaBuilderAlter(unittest.TestCase):
 
         self.assertEqual(blueprint.to_sql(), sql)
 
+    def test_can_add_constraints(self):
+        with self.schema.table("users") as blueprint:
+            blueprint.unique("name", name="table_unique")
+
+        self.assertEqual(len(blueprint.table.added_columns), 0)
+
+        sql = ['CREATE UNIQUE INDEX table_unique ON "users"(name)']
+
+        self.assertEqual(blueprint.to_sql(), sql)
+
     def test_alter_rename(self):
         with self.schema.table("users") as blueprint:
             blueprint.rename("post", "comment", "integer")


### PR DESCRIPTION
Closes #472 

@jrouffiac Issue here was just that the mysql platform was building own own index name. This was the old way before the addition of specifying your own index names. Must have just missed the unique on the refactor.

This was also an issue for the other platforms as well (postgres and MSSQL)