### PR TITLE
Feature/479

### DIFF
--- a/src/masoniteorm/connections/MSSQLConnection.py
+++ b/src/masoniteorm/connections/MSSQLConnection.py
@@ -57,9 +57,8 @@ class MSSQLConnection(BaseConnection):
             return self.get_global_connection()
 
         mssql_driver = self.options.get("driver", "ODBC Driver 17 for SQL Server")
-
         self._connection = pyodbc.connect(
-            f"DRIVER={mssql_driver};SERVER={self.host},{self.port};DATABASE={self.database};UID={self.user};PWD={self.password}{'Trusted_Connection=yes' if self.options.get('trusted_connection') else ''}",
+            f"DRIVER={mssql_driver};SERVER={self.host},{self.port};DATABASE={self.database};UID={self.user};PWD={self.password}{';Trusted_Connection=Yes' if self.options.get('trusted_connection') else ''}",
             autocommit=True,
         )
 

--- a/src/masoniteorm/connections/MSSQLConnection.py
+++ b/src/masoniteorm/connections/MSSQLConnection.py
@@ -58,15 +58,16 @@ class MSSQLConnection(BaseConnection):
 
         driver = self.options.get("driver", "ODBC Driver 17 for SQL Server")
         integrated_security = self.options.get("integrated_security")
-        connection_timeout = self.options.get("connection_timeout", "30")
-        authentication = self.options.get('authentication')
-        instance = self.options.get('instance', "")
+        connection_timeout = str(self.options.get("connection_timeout", "30"))
+        authentication = self.options.get("authentication")
+        instance = self.options.get("instance", "")
+        trusted_connection = self.options.get("trusted_connection")
 
         if instance:
-            instance = "\\" + instance 
+            instance = "\\" + instance
 
         self._connection = pyodbc.connect(
-            f"DRIVER={driver};SERVER={self.host}{instance if instance else ''},{self.port};Connection Timeout={connection_timeout};DATABASE={self.database}{f';Integrated Security={integrated_security}' if integrated_security else ''};UID={self.user};PWD={self.password}{';Trusted_Connection=Yes' if self.options.get('trusted_connection') else ''}{f';Authentication={authentication}' if authentication else ''}",
+            f"DRIVER={driver};SERVER={self.host}{instance if instance else ''},{self.port};Connection Timeout={connection_timeout};DATABASE={self.database}{f';Integrated Security={integrated_security}' if integrated_security else ''};UID={self.user};PWD={self.password}{f';Trusted_Connection={trusted_connection}' if trusted_connection else ''}{f';Authentication={authentication}' if authentication else ''}",
             autocommit=True,
         )
 

--- a/src/masoniteorm/connections/MSSQLConnection.py
+++ b/src/masoniteorm/connections/MSSQLConnection.py
@@ -59,7 +59,7 @@ class MSSQLConnection(BaseConnection):
         mssql_driver = self.options.get("driver", "ODBC Driver 17 for SQL Server")
 
         self._connection = pyodbc.connect(
-            f"DRIVER={mssql_driver};SERVER={self.host},{self.port};DATABASE={self.database};UID={self.user};PWD={self.password}",
+            f"DRIVER={mssql_driver};SERVER={self.host},{self.port};DATABASE={self.database};UID={self.user};PWD={self.password}{'Trusted_Connection=yes' if self.options.get('trusted_connection') else ''}"
             autocommit=True,
         )
 

--- a/src/masoniteorm/connections/MSSQLConnection.py
+++ b/src/masoniteorm/connections/MSSQLConnection.py
@@ -56,9 +56,17 @@ class MSSQLConnection(BaseConnection):
         if self.has_global_connection():
             return self.get_global_connection()
 
-        mssql_driver = self.options.get("driver", "ODBC Driver 17 for SQL Server")
+        driver = self.options.get("driver", "ODBC Driver 17 for SQL Server")
+        integrated_security = self.options.get("integrated_security")
+        connection_timeout = self.options.get("connection_timeout", "30")
+        authentication = self.options.get('authentication')
+        instance = self.options.get('instance', "")
+
+        if instance:
+            instance = "\\" + instance 
+
         self._connection = pyodbc.connect(
-            f"DRIVER={mssql_driver};SERVER={self.host},{self.port};DATABASE={self.database};UID={self.user};PWD={self.password}{';Trusted_Connection=Yes' if self.options.get('trusted_connection') else ''}",
+            f"DRIVER={driver};SERVER={self.host}{instance if instance else ''},{self.port};Connection Timeout={connection_timeout};DATABASE={self.database}{f';Integrated Security={integrated_security}' if integrated_security else ''};UID={self.user};PWD={self.password}{';Trusted_Connection=Yes' if self.options.get('trusted_connection') else ''}{f';Authentication={authentication}' if authentication else ''}",
             autocommit=True,
         )
 

--- a/src/masoniteorm/connections/MSSQLConnection.py
+++ b/src/masoniteorm/connections/MSSQLConnection.py
@@ -59,7 +59,7 @@ class MSSQLConnection(BaseConnection):
         mssql_driver = self.options.get("driver", "ODBC Driver 17 for SQL Server")
 
         self._connection = pyodbc.connect(
-            f"DRIVER={mssql_driver};SERVER={self.host},{self.port};DATABASE={self.database};UID={self.user};PWD={self.password}{'Trusted_Connection=yes' if self.options.get('trusted_connection') else ''}"
+            f"DRIVER={mssql_driver};SERVER={self.host},{self.port};DATABASE={self.database};UID={self.user};PWD={self.password}{'Trusted_Connection=yes' if self.options.get('trusted_connection') else ''}",
             autocommit=True,
         )
 


### PR DESCRIPTION
Closes #479 

Adds available options:

```python
            "trusted_connection": "Yes",
            "integrated_security": "sspi",
            "instance": "SQLExpress",
            "authentication": "ActiveDirectoryPassword",
            "driver": "ODBC Driver 17 for SQL Server",
            "connection_timeout": 15,
```