### PR TITLE
Fix for scopes/UUIDPrimaryKeyScope.py always replacing primary_key

### DIFF
--- a/src/masoniteorm/scopes/UUIDPrimaryKeyScope.py
+++ b/src/masoniteorm/scopes/UUIDPrimaryKeyScope.py
@@ -23,7 +23,9 @@ class UUIDPrimaryKeyScope(BaseScope):
         return str(uuid_func(*args))
 
     def set_uuid_create(self, builder):
-        uuid_version = getattr(builder._model, "__uuid_version__", 4)
-        builder._creates.update(
-            {builder._model.__primary_key__: self.generate_uuid(builder, uuid_version)}
-        )
+        # if there is already a primary key, no need to set a new one
+        if not builder._model.__primary_key__:
+            uuid_version = getattr(builder._model, "__uuid_version__", 4)
+            builder._creates.update(
+                {builder._model.__primary_key__: self.generate_uuid(builder, uuid_version)}
+            )

--- a/src/masoniteorm/scopes/UUIDPrimaryKeyScope.py
+++ b/src/masoniteorm/scopes/UUIDPrimaryKeyScope.py
@@ -27,5 +27,9 @@ class UUIDPrimaryKeyScope(BaseScope):
         if builder._model.__primary_key__ not in builder._creates:
             uuid_version = getattr(builder._model, "__uuid_version__", 4)
             builder._creates.update(
-                {builder._model.__primary_key__: self.generate_uuid(builder, uuid_version)}
+                {
+                    builder._model.__primary_key__: self.generate_uuid(
+                        builder, uuid_version
+                    )
+                }
             )

--- a/src/masoniteorm/scopes/UUIDPrimaryKeyScope.py
+++ b/src/masoniteorm/scopes/UUIDPrimaryKeyScope.py
@@ -24,7 +24,7 @@ class UUIDPrimaryKeyScope(BaseScope):
 
     def set_uuid_create(self, builder):
         # if there is already a primary key, no need to set a new one
-        if not builder._model.__primary_key__:
+        if builder._model.__primary_key__ not in builder._creates:
             uuid_version = getattr(builder._model, "__uuid_version__", 4)
             builder._creates.update(
                 {builder._model.__primary_key__: self.generate_uuid(builder, uuid_version)}

--- a/tests/scopes/test_default_global_scopes.py
+++ b/tests/scopes/test_default_global_scopes.py
@@ -59,6 +59,7 @@ class TestUUIDPrimaryKeyScope(unittest.TestCase):
             self.scope.set_uuid_create(self.builder)
             uuid_value = uuid.UUID(self.builder._creates["id"])
             self.assertEqual(version, uuid_value.version)
+            del self.builder._creates["id"]
 
     def test_works_with_custom_pk_column(self):
         UserWithUUID.__primary_key__ = "ref"


### PR DESCRIPTION
Fix for scopes/UUIDPrimaryKeyScope.py always replacing the primary_key.  It should only provide a primary_key when one has not been provided.