### PR TITLE
@BelongsToMany getting owner table name from wrong source?

### DIFF
--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -71,7 +71,7 @@ class BelongsToMany(BaseRelationship):
             self.other_foreign_key = self.other_foreign_key or f"{pivot_table_1}_id"
             self.local_foreign_key = self.local_foreign_key or f"{pivot_table_2}_id"
 
-        table1 = owner.builder.get_table_name()
+        table1 = owner.get_table_name()
         table2 = query.get_table_name()
         result = query.select(
             f"{query.get_table_name()}.*",


### PR DESCRIPTION
I've been trying to get the `@BelongsToMany` to work for a couple of hours now.  I kept getting an error about the model class: `AttributeError: class model 'Client' has no attribute builder`.  

When I tracked this down to masoniteorm/relationships/BelongsToMany.py, it appears that the code to get the name of the owner table is wrong.  When I fix this line (as noted in the commit), everything works as documented.

I believe this is the correct way to fix this issue, but as I have discovered on a previous commit, I may not have understood how things work enough.