### PR TITLE
Add a way to customize configuration location

### DIFF
--- a/src/masoniteorm/commands/CanOverrideConfig.py
+++ b/src/masoniteorm/commands/CanOverrideConfig.py
@@ -8,6 +8,9 @@ class CanOverrideConfig(Command):
 
     def add_option(self):
         self._config.add_option(
-            "option", "o", 8, "The location of the config module", None
+            "option",
+            "o",
+            8,
+            "The path to the ORM configuration file. If not given DB_CONFIG_PATH env variable will be used and finally 'config.database'.",
+            None,
         )
-

--- a/src/masoniteorm/commands/CanOverrideConfig.py
+++ b/src/masoniteorm/commands/CanOverrideConfig.py
@@ -7,8 +7,10 @@ class CanOverrideConfig(Command):
         self.add_option()
 
     def add_option(self):
+        # 8 is the required flag constant in cleo
         self._config.add_option(
             "config",
             "C",
+            8,
             description="The path to the ORM configuration file. If not given DB_CONFIG_PATH env variable will be used and finally 'config.database'.",
         )

--- a/src/masoniteorm/commands/CanOverrideConfig.py
+++ b/src/masoniteorm/commands/CanOverrideConfig.py
@@ -1,0 +1,13 @@
+from cleo.commands.command import Command
+
+
+class CanOverrideConfig(Command):
+    def __init__(self):
+        super().__init__()
+        self.add_option()
+
+    def add_option(self):
+        self._config.add_option(
+            "option", "o", 8, "The location of the config module", None
+        )
+

--- a/src/masoniteorm/commands/CanOverrideConfig.py
+++ b/src/masoniteorm/commands/CanOverrideConfig.py
@@ -9,8 +9,6 @@ class CanOverrideConfig(Command):
     def add_option(self):
         self._config.add_option(
             "config",
-            "f",
-            8,
-            "The path to the ORM configuration file. If not given DB_CONFIG_PATH env variable will be used and finally 'config.database'.",
-            None,
+            "C",
+            description="The path to the ORM configuration file. If not given DB_CONFIG_PATH env variable will be used and finally 'config.database'.",
         )

--- a/src/masoniteorm/commands/CanOverrideConfig.py
+++ b/src/masoniteorm/commands/CanOverrideConfig.py
@@ -8,8 +8,8 @@ class CanOverrideConfig(Command):
 
     def add_option(self):
         self._config.add_option(
-            "option",
-            "o",
+            "config",
+            "f",
             8,
             "The path to the ORM configuration file. If not given DB_CONFIG_PATH env variable will be used and finally 'config.database'.",
             None,

--- a/src/masoniteorm/commands/MigrateCommand.py
+++ b/src/masoniteorm/commands/MigrateCommand.py
@@ -1,9 +1,9 @@
-from cleo import Command
 import os
 from ..migrations import Migration
+from .CanOverrideConfig import CanOverrideConfig
 
 
-class MigrateCommand(Command):
+class MigrateCommand(CanOverrideConfig):
     """
     Run migrations.
 
@@ -30,6 +30,7 @@ class MigrateCommand(Command):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
+            config_path=self.option("option"),
         )
         migration.create_table_if_not_exists()
         if not migration.get_unran_migrations():

--- a/src/masoniteorm/commands/MigrateCommand.py
+++ b/src/masoniteorm/commands/MigrateCommand.py
@@ -30,7 +30,7 @@ class MigrateCommand(CanOverrideConfig):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
-            config_path=self.option("option"),
+            config_path=self.option("config"),
         )
         migration.create_table_if_not_exists()
         if not migration.get_unran_migrations():

--- a/src/masoniteorm/commands/MigrateRefreshCommand.py
+++ b/src/masoniteorm/commands/MigrateRefreshCommand.py
@@ -18,7 +18,7 @@ class MigrateRefreshCommand(CanOverrideConfig):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
-            config_path=self.option("option"),
+            config_path=self.option("config"),
         )
 
         migration.refresh()

--- a/src/masoniteorm/commands/MigrateRefreshCommand.py
+++ b/src/masoniteorm/commands/MigrateRefreshCommand.py
@@ -1,8 +1,8 @@
-from cleo import Command
+from .CanOverrideConfig import CanOverrideConfig
 from ..migrations import Migration
 
 
-class MigrateRefreshCommand(Command):
+class MigrateRefreshCommand(CanOverrideConfig):
     """
     Rolls back all migrations and migrates them again.
 
@@ -18,6 +18,7 @@ class MigrateRefreshCommand(Command):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
+            config_path=self.option("option"),
         )
 
         migration.refresh()

--- a/src/masoniteorm/commands/MigrateResetCommand.py
+++ b/src/masoniteorm/commands/MigrateResetCommand.py
@@ -16,6 +16,6 @@ class MigrateResetCommand(CanOverrideConfig):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
-            config_path=self.option("option"),
+            config_path=self.option("config"),
         )
         migration.reset()

--- a/src/masoniteorm/commands/MigrateResetCommand.py
+++ b/src/masoniteorm/commands/MigrateResetCommand.py
@@ -1,8 +1,8 @@
-from cleo import Command
+from .CanOverrideConfig import CanOverrideConfig
 from ..migrations import Migration
 
 
-class MigrateResetCommand(Command):
+class MigrateResetCommand(CanOverrideConfig):
     """
     Rolls back all migrations.
 
@@ -16,5 +16,6 @@ class MigrateResetCommand(Command):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
+            config_path=self.option("option"),
         )
         migration.reset()

--- a/src/masoniteorm/commands/MigrateRollbackCommand.py
+++ b/src/masoniteorm/commands/MigrateRollbackCommand.py
@@ -1,9 +1,8 @@
-from cleo import Command
-
+from .CanOverrideConfig import CanOverrideConfig
 from ..migrations import Migration
 
 
-class MigrateRollbackCommand(Command):
+class MigrateRollbackCommand(CanOverrideConfig):
     """
     Rolls back the last batch of migrations.
 
@@ -18,4 +17,5 @@ class MigrateRollbackCommand(Command):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
+            config_path=self.option("option"),
         ).rollback(output=self.option("show"))

--- a/src/masoniteorm/commands/MigrateRollbackCommand.py
+++ b/src/masoniteorm/commands/MigrateRollbackCommand.py
@@ -17,5 +17,5 @@ class MigrateRollbackCommand(CanOverrideConfig):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
-            config_path=self.option("option"),
+            config_path=self.option("config"),
         ).rollback(output=self.option("show"))

--- a/src/masoniteorm/commands/MigrateStatusCommand.py
+++ b/src/masoniteorm/commands/MigrateStatusCommand.py
@@ -1,8 +1,8 @@
-from cleo import Command
+from .CanOverrideConfig import CanOverrideConfig
 from ..migrations import Migration
 
 
-class MigrateStatusCommand(Command):
+class MigrateStatusCommand(CanOverrideConfig):
     """
     Display migrations status.
 
@@ -16,6 +16,7 @@ class MigrateStatusCommand(Command):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
+            config_path=self.option("option"),
         )
         migration.create_table_if_not_exists()
         table = self.table()

--- a/src/masoniteorm/commands/MigrateStatusCommand.py
+++ b/src/masoniteorm/commands/MigrateStatusCommand.py
@@ -16,7 +16,7 @@ class MigrateStatusCommand(CanOverrideConfig):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
-            config_path=self.option("option"),
+            config_path=self.option("config"),
         )
         migration.create_table_if_not_exists()
         table = self.table()

--- a/src/masoniteorm/config.py
+++ b/src/masoniteorm/config.py
@@ -1,0 +1,23 @@
+import os
+import pydoc
+
+from .exceptions import ConfigurationNotFound
+
+
+def load_config(config_path=None):
+    """Load ORM configuration from given configuration path (dotted or not).
+    If no path is provided:
+        1. try to load from DB_CONFIG_PATH environment variable
+        2. else try to load from default config_path: config/database
+    """
+    selected_config_path = (
+        config_path or os.getenv("DB_CONFIG_PATH", None) or "config/database"
+    )
+    # format path as python module if needed
+    selected_config_path = selected_config_path.replace("/", ".").rstrip(".py")
+    config_module = pydoc.locate(selected_config_path)
+    if config_module is None:
+        raise ConfigurationNotFound(
+            f"ORM configuration file has not been found in {selected_config_path}."
+        )
+    return config_module

--- a/src/masoniteorm/connections/ConnectionFactory.py
+++ b/src/masoniteorm/connections/ConnectionFactory.py
@@ -1,3 +1,6 @@
+from ..config import load_config
+
+
 class ConnectionFactory:
     """Class for controlling the registration and creation of connection types."""
 
@@ -32,9 +35,9 @@ class ConnectionFactory:
             masoniteorm.connection.BaseConnection -- Returns an instance of a BaseConnection class.
         """
 
-        from config.database import ConnectionResolver
+        DB = load_config().DB
 
-        connections = ConnectionResolver().get_connection_details()
+        connections = DB.get_connection_details()
 
         if key == "default":
             connection_details = connections.get(connections.get("default"))

--- a/src/masoniteorm/exceptions.py
+++ b/src/masoniteorm/exceptions.py
@@ -20,3 +20,7 @@ class QueryException(Exception):
 
 class MigrationNotFound(Exception):
     pass
+
+
+class ConfigurationNotFound(Exception):
+    pass

--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -7,6 +7,7 @@ from inflection import camelize
 
 from ..models.MigrationModel import MigrationModel
 from ..schema import Schema
+from ..config import load_config
 
 from timeit import default_timer as timer
 
@@ -18,13 +19,14 @@ class Migration:
         dry=False,
         command_class=None,
         migration_directory="databases/migrations",
+        config_path=None,
     ):
         self.connection = connection
         self.migration_directory = migration_directory
         self.last_migrations_ran = []
         self.command_class = command_class
 
-        from config.database import DB
+        DB = load_config(config_path).DB
 
         DATABASES = DB.get_connection_details()
 

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -8,6 +8,7 @@ from ..query import QueryBuilder
 from ..collection import Collection
 from ..observers import ObservesEvents
 from ..scopes import TimeStampsMixin
+from ..config import load_config
 
 """This is a magic class that will help using models like User.first() instead of having to instatiate a class like
 User().first()
@@ -260,9 +261,8 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         return self.builder.select(*self.__selects__)
 
     def get_connection_details(self):
-        from config.database import ConnectionResolver
-
-        return ConnectionResolver().get_connection_details()
+        DB = load_config().DB
+        return DB.get_connection_details()
 
     def boot(self):
         if not self._booted:

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1,5 +1,6 @@
 import inspect
 
+from ..config import load_config
 from ..collection.Collection import Collection
 from ..expressions.expressions import (
     JoinClause,
@@ -93,8 +94,7 @@ class QueryBuilder(ObservesEvents):
         self.set_action("select")
 
         if not self._connection_details:
-            from config.database import DB
-
+            DB = load_config().DB
             self._connection_details = DB.get_connection_details()
 
         self.on(connection)
@@ -360,7 +360,7 @@ class QueryBuilder(ObservesEvents):
         )
 
     def on(self, connection):
-        from config.database import DB
+        DB = load_config().DB
 
         if connection == "default":
             self.connection = self._connection_details.get("default")

--- a/src/masoniteorm/schema/Schema.py
+++ b/src/masoniteorm/schema/Schema.py
@@ -2,6 +2,7 @@ from .Blueprint import Blueprint
 from .Table import Table
 from .TableDiff import TableDiff
 from ..exceptions import ConnectionNotRegistered
+from ..config import load_config
 
 
 class Schema:
@@ -44,7 +45,7 @@ class Schema:
         Returns:
             cls
         """
-        from config.database import DB
+        DB = load_config().DB
 
         if connection_key == "default":
             self.connection = self.connection_details.get("default")


### PR DESCRIPTION
Try to fix #501.
Based on the discussions in the issue, here is what I propose:

## Normal usage
1. By default Masonite ORM will look for a `DB_CONFIG_PATH` env variable which should contain the path to the configuration file.
2. If this variable is not defined, Masonite ORM will look for a `config/database.py` file (which is the database configuration file for Masonite).

## ORM commands usage
In the commands we now have a way to override the configuration path with the `--config` option. This option, if given takes precedence over the two others options.

```bash
$ orm migrate -C app/config/db
```

So in this case it becomes:
1. Masonite ORM will use the path given in command option.
2. If no option is given, Masonite ORM will look for a `DB_CONFIG_PATH` env variable which should contain the path to the configuration file.
3. If this variable is not defined, Masonite ORM will look for a `config/database.py` file (which is the database configuration file for Masonite).

## Path to the configuration file
The path can be a python path or a file path. All paths below are accepted:
```python
app/config/database.py
app/config/database
app.config.database
app.config.database.py
```
![image](https://user-images.githubusercontent.com/9897999/136431303-55756bc6-7e38-429c-b81a-af9e19fd637b.png)

Only little detail is that as : `-c` is already taken by connection and `-s` by show, I can't use them for short name of `--config` or `--settings`. So for now I have kept `--config` and `-C` (uppercased) as short name...I am open to proposals.
 