### PR TITLE
Fix Faker being reset for every registered call and after create

### DIFF
--- a/src/masoniteorm/factories/Factory.py
+++ b/src/masoniteorm/factories/Factory.py
@@ -1,10 +1,21 @@
 from faker import Faker
+import random
 
 
 class Factory:
 
     _factories = {}
     _after_creates = {}
+    _faker = None
+
+    @property
+    def faker(self):
+        if not Factory._faker:
+            Factory._faker = Faker()
+            random.seed()
+            Factory._faker.seed_instance(random.randint(1, 10000))
+
+        return Factory._faker
 
     def __init__(self, model, number=1):
         self.model = model
@@ -15,7 +26,7 @@ class Factory:
             dictionary = {}
 
         if self.number == 1 and not isinstance(dictionary, list):
-            called = self._factories[self.model][name](Faker())
+            called = self._factories[self.model][name](self.faker)
             called.update(dictionary)
             model = self.model.hydrate(called)
             self.run_after_creates(model)
@@ -23,7 +34,7 @@ class Factory:
         elif isinstance(dictionary, list):
             results = []
             for index in range(0, len(dictionary)):
-                called = self._factories[self.model][name](Faker())
+                called = self._factories[self.model][name](self.faker)
                 called.update(dictionary)
                 results.append(called)
             models = self.model.hydrate(results)
@@ -34,7 +45,7 @@ class Factory:
         else:
             results = []
             for index in range(0, self.number):
-                called = self._factories[self.model][name](Faker())
+                called = self._factories[self.model][name](self.faker)
                 called.update(dictionary)
                 results.append(called)
             models = self.model.hydrate(results)
@@ -47,7 +58,7 @@ class Factory:
             dictionary = {}
 
         if self.number == 1 and not isinstance(dictionary, list):
-            called = self._factories[self.model][name](Faker())
+            called = self._factories[self.model][name](self.faker)
             called.update(dictionary)
             model = self.model.create(called)
             self.run_after_creates(model)
@@ -55,7 +66,7 @@ class Factory:
         elif isinstance(dictionary, list):
             results = []
             for index in range(0, len(dictionary)):
-                called = self._factories[self.model][name](Faker())
+                called = self._factories[self.model][name](self.faker)
                 called.update(dictionary)
                 results.append(called)
 
@@ -66,7 +77,7 @@ class Factory:
         else:
             full_collection = []
             for index in range(0, self.number):
-                called = self._factories[self.model][name](Faker())
+                called = self._factories[self.model][name](self.faker)
                 called.update(dictionary)
                 full_collection.append(called)
                 model = self.model.create(called)
@@ -93,4 +104,4 @@ class Factory:
             return model
 
         for name, callback in self._after_creates[self.model].items():
-            callback(model, Faker())
+            callback(model, self.faker)


### PR DESCRIPTION
This Fixes the faker instance producing duplicate data when using .unique
This was due to a new Faker instance being created every time a factory callback is used

Example being if a factory is used to create multiple  users that each required a unique email address, the same email address would be generated every time even if faker.unique.ascii_email is used