### PR TITLE
Feat/516 - Migrate and Rollback migration by name

### DIFF
--- a/src/masoniteorm/commands/MigrateCommand.py
+++ b/src/masoniteorm/commands/MigrateCommand.py
@@ -8,6 +8,7 @@ class MigrateCommand(Command):
     Run migrations.
 
     migrate
+        {--m|migration=all : Migration's name to be migrated}
         {--c|connection=default : The connection you want to run migrations on}
         {--f|force : Force migrations without prompt in production}
         {--s|show : Shows the output of SQL for migrations that would be running}
@@ -36,4 +37,7 @@ class MigrateCommand(Command):
             self.info("Nothing To Migrate!")
             return
 
-        migration.migrate(output=self.option("show"))
+        migration_name = self.option("migration")
+        show_output = self.option("show")
+
+        migration.migrate(migration=migration_name, output=show_output)

--- a/src/masoniteorm/commands/MigrateRollbackCommand.py
+++ b/src/masoniteorm/commands/MigrateRollbackCommand.py
@@ -8,6 +8,7 @@ class MigrateRollbackCommand(Command):
     Rolls back the last batch of migrations.
 
     migrate:rollback
+        {--m|migration=all : Migration's name to be rollback}
         {--c|connection=default : The connection you want to run migrations on}
         {--s|show : Shows the output of SQL for migrations that would be running}
         {--d|directory=databases/migrations : The location of the migration directory}
@@ -18,4 +19,4 @@ class MigrateRollbackCommand(Command):
             command_class=self,
             connection=self.option("connection"),
             migration_directory=self.option("directory"),
-        ).rollback(output=self.option("show"))
+        ).rollback(migration=self.option("migration"), output=self.option("show"))

--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -106,21 +106,18 @@ class Migration:
                 ran.append(migration)
         return ran
 
-    def migrate(self, output=False):
+    def migrate(self, migration=None, output=False):
+        
+        migrations_to_migrate = self.get_unran_migrations() if migration == 'all' else [migration]
+
         batch = self.get_last_batch_number() + 1
 
-        for migration in self.get_unran_migrations():
-            migration_module = migration.replace(".py", "")
-            migration_name = camelize(
-                "_".join(migration.split("_")[4:]).replace(".py", "")
-            )
-
-            migration_directory = self.migration_directory.replace("/", ".")
-
+        for migration in migrations_to_migrate:
+            
             try:
-                migration_class = locate(
-                    f"{migration_directory}.{migration_module}.{migration_name}"
-                )
+
+                migration_class = self.locate(migration)
+
             except TypeError:
                 self.command_class.line(f"<error>Not Found: {migration}</error>")
                 continue

--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -107,14 +107,14 @@ class Migration:
         return ran
 
     def migrate(self, migration=None, output=False):
-        
+
         default_migrations = self.get_unran_migrations()
-        migrations = default_migrations if migration == 'all' else [migration]
+        migrations = default_migrations if migration == "all" else [migration]
 
         batch = self.get_last_batch_number() + 1
 
         for migration in migrations:
-            
+
             try:
                 migration_class = self.locate(migration)
 
@@ -159,14 +159,16 @@ class Migration:
             )
 
     def rollback(self, migration=None, output=False):
-        
+
         default_migrations = self.get_rollback_migrations()
-        migrations = default_migrations if migration == 'all' else [migration]
+        migrations = default_migrations if migration == "all" else [migration]
 
         for migration in migrations:
 
             if self.command_class:
-                self.command_class.line(f"<comment>Rolling back:</comment> <question>{migration}</question>")
+                self.command_class.line(
+                    f"<comment>Rolling back:</comment> <question>{migration}</question>"
+                )
 
             try:
                 migration_class = self.locate(migration)

--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -108,14 +108,14 @@ class Migration:
 
     def migrate(self, migration=None, output=False):
         
-        migrations_to_migrate = self.get_unran_migrations() if migration == 'all' else [migration]
+        default_migrations = self.get_unran_migrations()
+        migrations = default_migrations if migration == 'all' else [migration]
 
         batch = self.get_last_batch_number() + 1
 
-        for migration in migrations_to_migrate:
+        for migration in migrations:
             
             try:
-
                 migration_class = self.locate(migration)
 
             except TypeError:
@@ -158,18 +158,23 @@ class Migration:
                 {"batch": batch, "migration": migration.replace(".py", "")}
             )
 
-    def rollback(self, output=False):
-        for migration in self.get_rollback_migrations():
+    def rollback(self, migration=None, output=False):
+        
+        default_migrations = self.get_rollback_migrations()
+        migrations = default_migrations if migration == 'all' else [migration]
+
+        for migration in migrations:
+
             if self.command_class:
-                self.command_class.line(
-                    f"<comment>Rolling back:</comment> <question>{migration}</question>"
-                )
+                self.command_class.line(f"<comment>Rolling back:</comment> <question>{migration}</question>")
 
             try:
-                migration_class = self.locate(migration)(connection=self.connection)
+                migration_class = self.locate(migration)
             except TypeError:
                 self.command_class.line(f"<error>Not Found: {migration}</error>")
                 continue
+
+            migration_class = migration_class(connection=self.connection)
 
             if output:
                 migration_class.schema.dry()

--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -106,7 +106,7 @@ class Migration:
                 ran.append(migration)
         return ran
 
-    def migrate(self, migration=None, output=False):
+    def migrate(self, migration="all", output=False):
 
         default_migrations = self.get_unran_migrations()
         migrations = default_migrations if migration == "all" else [migration]
@@ -158,7 +158,7 @@ class Migration:
                 {"batch": batch, "migration": migration.replace(".py", "")}
             )
 
-    def rollback(self, migration=None, output=False):
+    def rollback(self, migration="all", output=False):
 
         default_migrations = self.get_rollback_migrations()
         migrations = default_migrations if migration == "all" else [migration]

--- a/src/masoniteorm/relationships/BelongsToMany.py
+++ b/src/masoniteorm/relationships/BelongsToMany.py
@@ -22,14 +22,14 @@ class BelongsToMany(BaseRelationship):
     ):
         if isinstance(fn, str):
             self.fn = None
-            self.local_foreign_key = fn
-            self.other_foreign_key = local_foreign_key
+            self.local_key = fn
+            self.foreign_key = local_foreign_key
             self.local_owner_key = other_foreign_key or "id"
             self.other_owner_key = local_owner_key or "id"
         else:
             self.fn = fn
-            self.local_foreign_key = local_foreign_key
-            self.other_foreign_key = other_foreign_key
+            self.local_key = local_foreign_key
+            self.foreign_key = other_foreign_key
             self.local_owner_key = local_owner_key or "id"
             self.other_owner_key = other_owner_key or "id"
 
@@ -40,8 +40,8 @@ class BelongsToMany(BaseRelationship):
         self.with_fields = with_fields
 
     def set_keys(self, owner, attribute):
-        self.local_foreign_key = self.local_foreign_key or "id"
-        self.other_foreign_key = self.other_foreign_key or f"{attribute}_id"
+        self.local_key = self.local_key or "id"
+        self.foreign_key = self.foreign_key or f"{attribute}_id"
         return self
 
     def apply_query(self, query, owner):
@@ -64,19 +64,19 @@ class BelongsToMany(BaseRelationship):
             pivot_tables.sort()
             pivot_table_1, pivot_table_2 = pivot_tables
             self._table = "_".join(pivot_tables)
-            self.other_foreign_key = self.other_foreign_key or f"{pivot_table_1}_id"
-            self.local_foreign_key = self.local_foreign_key or f"{pivot_table_2}_id"
+            self.foreign_key = self.foreign_key or f"{pivot_table_1}_id"
+            self.local_key = self.local_key or f"{pivot_table_2}_id"
         else:
             pivot_table_1, pivot_table_2 = self._table.split("_", 1)
-            self.other_foreign_key = self.other_foreign_key or f"{pivot_table_1}_id"
-            self.local_foreign_key = self.local_foreign_key or f"{pivot_table_2}_id"
+            self.foreign_key = self.foreign_key or f"{pivot_table_1}_id"
+            self.local_key = self.local_key or f"{pivot_table_2}_id"
 
         table1 = owner.get_table_name()
         table2 = query.get_table_name()
         result = query.select(
             f"{query.get_table_name()}.*",
-            f"{self._table}.{self.local_foreign_key} as {self._table}_id",
-            f"{self._table}.{self.other_foreign_key} as m_reserved2",
+            f"{self._table}.{self.local_key} as {self._table}_id",
+            f"{self._table}.{self.foreign_key} as m_reserved2",
         ).table(f"{table1}")
 
         if self.pivot_id:
@@ -90,13 +90,13 @@ class BelongsToMany(BaseRelationship):
 
         result.join(
             f"{self._table}",
-            f"{self._table}.{self.local_foreign_key}",
+            f"{self._table}.{self.local_key}",
             "=",
             f"{table1}.{self.local_owner_key}",
         )
         result.join(
             f"{table2}",
-            f"{self._table}.{self.other_foreign_key}",
+            f"{self._table}.{self.foreign_key}",
             "=",
             f"{table2}.{self.other_owner_key}",
         )
@@ -114,8 +114,8 @@ class BelongsToMany(BaseRelationship):
 
         for model in result:
             pivot_data = {
-                self.local_foreign_key: getattr(model, f"{self._table}_id"),
-                self.other_foreign_key: getattr(model, "m_reserved2"),
+                self.local_key: getattr(model, f"{self._table}_id"),
+                self.foreign_key: getattr(model, "m_reserved2"),
             }
 
             if self.with_timestamps:
@@ -180,19 +180,19 @@ class BelongsToMany(BaseRelationship):
             pivot_tables.sort()
             pivot_table_1, pivot_table_2 = pivot_tables
             self._table = "_".join(pivot_tables)
-            self.other_foreign_key = self.other_foreign_key or f"{pivot_table_1}_id"
-            self.local_foreign_key = self.local_foreign_key or f"{pivot_table_2}_id"
+            self.foreign_key = self.foreign_key or f"{pivot_table_1}_id"
+            self.local_key = self.local_key or f"{pivot_table_2}_id"
         else:
             pivot_table_1, pivot_table_2 = self._table.split("_", 1)
-            self.other_foreign_key = self.other_foreign_key or f"{pivot_table_1}_id"
-            self.local_foreign_key = self.local_foreign_key or f"{pivot_table_2}_id"
+            self.foreign_key = self.foreign_key or f"{pivot_table_1}_id"
+            self.local_key = self.local_key or f"{pivot_table_2}_id"
 
         table2 = builder.get_table_name()
         table1 = query.get_table_name()
         result = builder.select(
             f"{table2}.*",
-            f"{self._table}.{self.local_foreign_key} as {self._table}_id",
-            f"{self._table}.{self.other_foreign_key} as m_reserved2",
+            f"{self._table}.{self.local_key} as {self._table}_id",
+            f"{self._table}.{self.foreign_key} as m_reserved2",
         ).table(f"{table1}")
 
         if self.with_fields:
@@ -201,14 +201,14 @@ class BelongsToMany(BaseRelationship):
 
         result.join(
             f"{self._table}",
-            f"{self._table}.{self.local_foreign_key}",
+            f"{self._table}.{self.local_key}",
             "=",
             f"{table1}.{self.local_owner_key}",
         )
 
         result.join(
             f"{table2}",
-            f"{self._table}.{self.other_foreign_key}",
+            f"{self._table}.{self.foreign_key}",
             "=",
             f"{table2}.{self.other_owner_key}",
         )
@@ -240,8 +240,8 @@ class BelongsToMany(BaseRelationship):
 
         for model in final_result:
             pivot_data = {
-                self.local_foreign_key: getattr(model, f"{self._table}_id"),
-                self.other_foreign_key: getattr(model, "m_reserved2"),
+                self.local_key: getattr(model, f"{self._table}_id"),
+                self.foreign_key: getattr(model, "m_reserved2"),
             }
 
             model.delete_attribute("m_reserved2")


### PR DESCRIPTION
Closes #516.

Add option to define migration to handle with. Migrate or rollback:

```
masonite-orm migrate --m migration_name
masonite-orm migrate:rollback --m migration_name
```

Ps: the value to migration name "migration_name" will be given by the results listed by migrate:status command.

- [ ] - Add modifications in doc repository