### PR TITLE
Fixed wrong spread bindings

### DIFF
--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -636,7 +636,7 @@ class BaseGrammar:
                 if qmark:
                     query_from_builder = value.builder.to_qmark()
                     if value.builder._bindings:
-                        self.add_binding(*value.builder._bindings)
+                        self.add_binding(value.builder._bindings)
                 else:
                     query_from_builder = value.builder.to_sql()
                 query_value = self.subquery_string().format(query=query_from_builder)

--- a/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
+++ b/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
@@ -227,6 +227,13 @@ class BaseTestCaseSelectGrammar:
         )()
         self.assertEqual(to_sql, sql)
 
+    def test_can_compile_sub_select_where(self):
+        to_sql = self.builder.where_in("age", self.builder.new().select("age").where('age', 2).where('name', 'Joe')).to_sql()
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(to_sql, sql)
+
     def test_can_compile_sub_select_value(self):
         to_sql = self.builder.where("name", self.builder.new().sum("age")).to_sql()
         sql = getattr(

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -179,6 +179,15 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
         return "SELECT * FROM [users] WHERE [users].[name] IN (SELECT [users].[age] FROM [users])"
 
+    def can_compile_sub_select_where(self):
+        """
+        self.builder.where_in('age',
+            self.builder.new().sum('age').where('age', 2).where('name', 'Joe')
+        ).to_sql()
+        """
+
+        return "SELECT * FROM [users] WHERE [users].[age] IN (SELECT [users].[age] FROM [users] WHERE [users].[age] = '2' AND [users].[name] = 'Joe')"
+
     def can_compile_sub_select_value(self):
         """
         self.builder.where('name',

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -182,7 +182,7 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def can_compile_sub_select_where(self):
         """
         self.builder.where_in('age',
-            self.builder.new().sum('age').where('age', 2).where('name', 'Joe')
+            QueryBuilder(GrammarFactory.make(self.grammar), table='users').select('age').where('age', 2).where('name', 'Joe')
         ).to_sql()
         """
 

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -185,6 +185,15 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
         return "SELECT * FROM `users` WHERE `users`.`name` IN (SELECT `users`.`age` FROM `users`)"
 
+    def can_compile_sub_select_where(self):
+        """
+        self.builder.where_in('age',
+            QueryBuilder(GrammarFactory.make(self.grammar), table='users').select('age').where('age', 2).where('name', 'Joe')
+        ).to_sql()
+        """
+
+        return "SELECT * FROM `users` WHERE `users`.`age` IN (SELECT `users`.`age` FROM `users` WHERE `users`.`age` = '2' AND `users`.`name` = 'Joe')"
+
     def can_compile_sub_select_value(self):
         """
         self.builder.where('name',

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -181,6 +181,15 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
         return """SELECT * FROM "users" WHERE "users"."name" IN (SELECT "users"."age" FROM "users")"""
 
+    def can_compile_sub_select_where(self):
+        """
+        self.builder.where_in('age',
+            QueryBuilder(GrammarFactory.make(self.grammar), table='users').select('age').where('age', 2).where('name', 'Joe')
+        ).to_sql()
+        """
+
+        return """SELECT * FROM "users" WHERE "users"."age" IN (SELECT "users"."age" FROM "users" WHERE "users"."age" = '2' AND "users"."name" = 'Joe')"""
+
     def can_compile_sub_select_value(self):
         """
         self.builder.where('name',

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -187,6 +187,15 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
         return """SELECT * FROM "users" WHERE "users"."name" IN (SELECT "users"."age" FROM "users")"""
 
+    def can_compile_sub_select_where(self):
+        """
+        self.builder.where('name',
+            self.builder.new().sum('age')
+        ).to_sql()
+        """
+
+        return """SELECT * FROM "users" WHERE "users"."age" IN (SELECT "users"."age" FROM "users" WHERE "users"."age" = '2' AND "users"."name" = 'Joe')"""
+
     def can_compile_sub_select_value(self):
         """
         self.builder.where('name',

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -189,8 +189,8 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
     def can_compile_sub_select_where(self):
         """
-        self.builder.where('name',
-            self.builder.new().sum('age')
+        self.builder.where_in('age',
+            QueryBuilder(GrammarFactory.make(self.grammar), table='users').select('age').where('age', 2).where('name', 'Joe')
         ).to_sql()
         """
 


### PR DESCRIPTION
I am developing an application in Python and I had the same problem related to issue #494 where it is not possible to use multiple wheres in a subquery

The add_binding function only expects a 'binding' parameter, however the value.builder._bindings variable is a list of bind values.

`add_binding(self, binding):`

`value.builder._bindings = ['value1', 'value2']`

In the current code a spread is being performed, however the list is one-dimensional this is causing the problem of too many arguments when multiple arguments in a subquery

**Current:**
```python
self.add_binding(*value.builder._bindings) --- result --> self.add_binding('value1', 'value2')
```

**New:**
```python
self.add_binding(value.builder._bindings) --- result --> self.add_binding(['value1', 'value2'])
```