### PR TITLE
Add ability to override default command options values from init()

### DIFF
--- a/src/masoniteorm/commands/CanOverrideConfig.py
+++ b/src/masoniteorm/commands/CanOverrideConfig.py
@@ -1,4 +1,4 @@
-from cleo.commands.command import Command
+from cleo import Command
 
 
 class CanOverrideConfig(Command):

--- a/src/masoniteorm/commands/CanOverrideOptionsDefault.py
+++ b/src/masoniteorm/commands/CanOverrideOptionsDefault.py
@@ -1,0 +1,14 @@
+class CanOverrideOptionsDefault:
+    """Command mixin to allow to override optional argument default values when instantiating the
+    command.
+
+    Example: SomeCommand(app, option1="other/default").
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.overriden_default = kwargs
+        for name, value in self.overriden_default.items():
+            option = self.config.options.get(name)
+            if option:
+                option.set_default(value)

--- a/src/masoniteorm/commands/Command.py
+++ b/src/masoniteorm/commands/Command.py
@@ -1,0 +1,6 @@
+from .CanOverrideConfig import CanOverrideConfig
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
+
+
+class Command(CanOverrideOptionsDefault, CanOverrideConfig):
+    pass

--- a/src/masoniteorm/commands/MakeMigrationCommand.py
+++ b/src/masoniteorm/commands/MakeMigrationCommand.py
@@ -2,12 +2,12 @@ import datetime
 import os
 import pathlib
 
-from cleo import Command
 from inflection import camelize, tableize
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
+
+from .Command import Command
 
 
-class MakeMigrationCommand(CanOverrideOptionsDefault, Command):
+class MakeMigrationCommand(Command):
     """
     Creates a new migration file.
 

--- a/src/masoniteorm/commands/MakeMigrationCommand.py
+++ b/src/masoniteorm/commands/MakeMigrationCommand.py
@@ -4,9 +4,10 @@ import pathlib
 
 from cleo import Command
 from inflection import camelize, tableize
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 
 
-class MakeMigrationCommand(Command):
+class MakeMigrationCommand(CanOverrideOptionsDefault, Command):
     """
     Creates a new migration file.
 

--- a/src/masoniteorm/commands/MakeModelCommand.py
+++ b/src/masoniteorm/commands/MakeModelCommand.py
@@ -3,9 +3,10 @@ import pathlib
 
 from cleo import Command
 from inflection import camelize, underscore, tableize
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 
 
-class MakeModelCommand(Command):
+class MakeModelCommand(CanOverrideOptionsDefault, Command):
     """
     Creates a new model file.
 

--- a/src/masoniteorm/commands/MakeModelCommand.py
+++ b/src/masoniteorm/commands/MakeModelCommand.py
@@ -1,12 +1,12 @@
 import os
 import pathlib
 
-from cleo import Command
-from inflection import camelize, underscore, tableize
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
+from inflection import camelize, tableize
+
+from .Command import Command
 
 
-class MakeModelCommand(CanOverrideOptionsDefault, Command):
+class MakeModelCommand(Command):
     """
     Creates a new model file.
 

--- a/src/masoniteorm/commands/MakeObserverCommand.py
+++ b/src/masoniteorm/commands/MakeObserverCommand.py
@@ -1,12 +1,12 @@
 import os
 import pathlib
 
-from cleo import Command
 from inflection import camelize, underscore
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
+
+from .Command import Command
 
 
-class MakeObserverCommand(CanOverrideOptionsDefault, Command):
+class MakeObserverCommand(Command):
     """
     Creates a new observer file.
 

--- a/src/masoniteorm/commands/MakeObserverCommand.py
+++ b/src/masoniteorm/commands/MakeObserverCommand.py
@@ -3,9 +3,10 @@ import pathlib
 
 from cleo import Command
 from inflection import camelize, underscore
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 
 
-class MakeObserverCommand(Command):
+class MakeObserverCommand(CanOverrideOptionsDefault, Command):
     """
     Creates a new observer file.
 

--- a/src/masoniteorm/commands/MakeSeedCommand.py
+++ b/src/masoniteorm/commands/MakeSeedCommand.py
@@ -1,12 +1,12 @@
 import os
 import pathlib
 
-from cleo import Command
 from inflection import camelize, underscore
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
+
+from .Command import Command
 
 
-class MakeSeedCommand(CanOverrideOptionsDefault, Command):
+class MakeSeedCommand(Command):
     """
     Creates a new seed file.
 

--- a/src/masoniteorm/commands/MakeSeedCommand.py
+++ b/src/masoniteorm/commands/MakeSeedCommand.py
@@ -2,12 +2,11 @@ import os
 import pathlib
 
 from cleo import Command
-from inflection import camelize
+from inflection import camelize, underscore
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 
-from inflection import underscore
 
-
-class MakeSeedCommand(Command):
+class MakeSeedCommand(CanOverrideOptionsDefault, Command):
     """
     Creates a new seed file.
 

--- a/src/masoniteorm/commands/MigrateCommand.py
+++ b/src/masoniteorm/commands/MigrateCommand.py
@@ -1,9 +1,10 @@
 import os
 from ..migrations import Migration
 from .CanOverrideConfig import CanOverrideConfig
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 
 
-class MigrateCommand(CanOverrideConfig):
+class MigrateCommand(CanOverrideOptionsDefault, CanOverrideConfig):
     """
     Run migrations.
 

--- a/src/masoniteorm/commands/MigrateCommand.py
+++ b/src/masoniteorm/commands/MigrateCommand.py
@@ -1,10 +1,10 @@
 import os
+
 from ..migrations import Migration
-from .CanOverrideConfig import CanOverrideConfig
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
+from .Command import Command
 
 
-class MigrateCommand(CanOverrideOptionsDefault, CanOverrideConfig):
+class MigrateCommand(Command):
     """
     Run migrations.
 

--- a/src/masoniteorm/commands/MigrateRefreshCommand.py
+++ b/src/masoniteorm/commands/MigrateRefreshCommand.py
@@ -1,8 +1,9 @@
 from .CanOverrideConfig import CanOverrideConfig
 from ..migrations import Migration
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 
 
-class MigrateRefreshCommand(CanOverrideConfig):
+class MigrateRefreshCommand(CanOverrideOptionsDefault, CanOverrideConfig):
     """
     Rolls back all migrations and migrates them again.
 

--- a/src/masoniteorm/commands/MigrateRefreshCommand.py
+++ b/src/masoniteorm/commands/MigrateRefreshCommand.py
@@ -1,9 +1,9 @@
-from .CanOverrideConfig import CanOverrideConfig
 from ..migrations import Migration
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
+
+from .Command import Command
 
 
-class MigrateRefreshCommand(CanOverrideOptionsDefault, CanOverrideConfig):
+class MigrateRefreshCommand(Command):
     """
     Rolls back all migrations and migrates them again.
 

--- a/src/masoniteorm/commands/MigrateResetCommand.py
+++ b/src/masoniteorm/commands/MigrateResetCommand.py
@@ -1,9 +1,8 @@
-from .CanOverrideConfig import CanOverrideConfig
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 from ..migrations import Migration
+from .Command import Command
 
 
-class MigrateResetCommand(CanOverrideOptionsDefault, CanOverrideConfig):
+class MigrateResetCommand(Command):
     """
     Rolls back all migrations.
 

--- a/src/masoniteorm/commands/MigrateResetCommand.py
+++ b/src/masoniteorm/commands/MigrateResetCommand.py
@@ -1,8 +1,9 @@
 from .CanOverrideConfig import CanOverrideConfig
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 from ..migrations import Migration
 
 
-class MigrateResetCommand(CanOverrideConfig):
+class MigrateResetCommand(CanOverrideOptionsDefault, CanOverrideConfig):
     """
     Rolls back all migrations.
 

--- a/src/masoniteorm/commands/MigrateRollbackCommand.py
+++ b/src/masoniteorm/commands/MigrateRollbackCommand.py
@@ -1,9 +1,8 @@
-from .CanOverrideConfig import CanOverrideConfig
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 from ..migrations import Migration
+from .Command import Command
 
 
-class MigrateRollbackCommand(CanOverrideOptionsDefault, CanOverrideConfig):
+class MigrateRollbackCommand(Command):
     """
     Rolls back the last batch of migrations.
 

--- a/src/masoniteorm/commands/MigrateRollbackCommand.py
+++ b/src/masoniteorm/commands/MigrateRollbackCommand.py
@@ -1,8 +1,9 @@
 from .CanOverrideConfig import CanOverrideConfig
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 from ..migrations import Migration
 
 
-class MigrateRollbackCommand(CanOverrideConfig):
+class MigrateRollbackCommand(CanOverrideOptionsDefault, CanOverrideConfig):
     """
     Rolls back the last batch of migrations.
 

--- a/src/masoniteorm/commands/MigrateStatusCommand.py
+++ b/src/masoniteorm/commands/MigrateStatusCommand.py
@@ -1,9 +1,8 @@
-from .CanOverrideConfig import CanOverrideConfig
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 from ..migrations import Migration
+from .Command import Command
 
 
-class MigrateStatusCommand(CanOverrideOptionsDefault, CanOverrideConfig):
+class MigrateStatusCommand(Command):
     """
     Display migrations status.
 

--- a/src/masoniteorm/commands/MigrateStatusCommand.py
+++ b/src/masoniteorm/commands/MigrateStatusCommand.py
@@ -1,8 +1,9 @@
 from .CanOverrideConfig import CanOverrideConfig
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 from ..migrations import Migration
 
 
-class MigrateStatusCommand(CanOverrideConfig):
+class MigrateStatusCommand(CanOverrideOptionsDefault, CanOverrideConfig):
     """
     Display migrations status.
 

--- a/src/masoniteorm/commands/SeedRunCommand.py
+++ b/src/masoniteorm/commands/SeedRunCommand.py
@@ -1,10 +1,10 @@
-from cleo import Command
-from ..seeds import Seeder
 from inflection import camelize, underscore
-from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
+
+from ..seeds import Seeder
+from .Command import Command
 
 
-class SeedRunCommand(CanOverrideOptionsDefault, Command):
+class SeedRunCommand(Command):
     """
     Run seeds.
 

--- a/src/masoniteorm/commands/SeedRunCommand.py
+++ b/src/masoniteorm/commands/SeedRunCommand.py
@@ -1,9 +1,10 @@
 from cleo import Command
 from ..seeds import Seeder
 from inflection import camelize, underscore
+from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 
 
-class SeedRunCommand(Command):
+class SeedRunCommand(CanOverrideOptionsDefault, Command):
     """
     Run seeds.
 


### PR DESCRIPTION
Now for all ORM commands we can update values of default options when initializing the command:

### Example with MakeModelCommand:

Default for `directory` is:
```python
        {--d|directory=app : The location of the model directory}
```
You need to pass a keyword argument with the same name as the option:
```python
MakeModelCommand(directory="app/models")
```
And 🎉 :
<img width="742" alt="image" src="https://user-images.githubusercontent.com/9897999/146990782-bfd468e4-8a3d-4ad0-a8ce-41235bb9c16b.png">

This will be useful to edit options from Masonite.