### PR TITLE
WIP: Add missing argument options to some commands

### DIFF
--- a/src/masoniteorm/commands/MakeModelCommand.py
+++ b/src/masoniteorm/commands/MakeModelCommand.py
@@ -16,6 +16,7 @@ class MakeModelCommand(Command):
         {--c|create : If the migration file should create a table}
         {--t|table : If the migration file should modify an existing table}
         {--d|directory=app : The location of the model directory}
+        {--D|migrations-directory=databases/migrations : The location of the migration directory}
     """
 
     def handle(self):
@@ -46,13 +47,14 @@ class MakeModelCommand(Command):
 
         self.info(f"Model created: {os.path.join(model_directory, file_name)}")
         if self.option("migration"):
+            migrations_directory = self.option("migrations-directory")
             if self.option("create"):
                 self.call(
                     "migration",
-                    f"create_{tableize(name)}_table --create {tableize(name)}",
+                    f"create_{tableize(name)}_table --create {tableize(name)} --directory {migrations_directory}",
                 )
             else:
                 self.call(
                     "migration",
-                    f"update_{tableize(name)}_table --table {tableize(name)}",
+                    f"update_{tableize(name)}_table --table {tableize(name)} --directory {migrations_directory}",
                 )

--- a/src/masoniteorm/commands/MakeObserverCommand.py
+++ b/src/masoniteorm/commands/MakeObserverCommand.py
@@ -13,6 +13,7 @@ class MakeObserverCommand(Command):
     observer
         {name : The name of the observer}
         {--m|model=None : The name of the model}
+        {--d|directory=app/observers : The location of the observers directory}
     """
 
     def handle(self):
@@ -21,7 +22,7 @@ class MakeObserverCommand(Command):
         if model == "None":
             model = name
 
-        observer_directory = "app/observers"
+        observer_directory = self.option("directory")
 
         with open(
             os.path.join(

--- a/src/masoniteorm/commands/MigrateRefreshCommand.py
+++ b/src/masoniteorm/commands/MigrateRefreshCommand.py
@@ -11,6 +11,7 @@ class MigrateRefreshCommand(Command):
         {--c|connection=default : The connection you want to run migrations on}
         {--d|directory=databases/migrations : The location of the migration directory}
         {--s|seed=? : Seed database after refresh. The seeder to be ran can be provided in argument}
+        {--D|seed-directory=databases/seeds : The location of the seed directory if seed option is used.}
     """
 
     def handle(self):
@@ -27,6 +28,9 @@ class MigrateRefreshCommand(Command):
         self.line("")
 
         if self.option("seed") == "null":
-            self.call("seed:run", "None")
+            self.call("seed:run", f"None --directory {self.option('seed-directory')}")
         elif self.option("seed"):
-            self.call("seed:run", self.option("seed"))
+            self.call(
+                "seed:run",
+                f"{self.option('seed')} --directory {self.option('seed-directory')}",
+            )


### PR DESCRIPTION
- MakeObserver was missing `directory` option
- MakeModel was missing `migrations-directory` option when the migration file is created with it
- MigrateRefresh was missing `seeds-directory` option when seed are ran after the command