### PR TITLE
Fix overriding command options when using dash in option name

### DIFF
--- a/src/masoniteorm/commands/CanOverrideOptionsDefault.py
+++ b/src/masoniteorm/commands/CanOverrideOptionsDefault.py
@@ -1,14 +1,22 @@
+from inflection import underscore
+
+
 class CanOverrideOptionsDefault:
     """Command mixin to allow to override optional argument default values when instantiating the
     command.
-
     Example: SomeCommand(app, option1="other/default").
+
+    If an argument long name is using - then use _ in keyword argument:
+    Example: SomeCommand(app, option_1="other/default") for an option named in option-1
     """
 
     def __init__(self, **kwargs):
         super().__init__()
         self.overriden_default = kwargs
-        for name, value in self.overriden_default.items():
-            option = self.config.options.get(name)
-            if option:
-                option.set_default(value)
+        for option_name, option in self.config.options.items():
+            # Cleo does not authorize _ in option name but - are authorized unfortunately -
+            # cannot be used in Python variables, so this make sure that option-a will be
+            # accessible with option_a in Python
+            default = self.overriden_default.get(underscore(option_name))
+            if default:
+                option.set_default(default)

--- a/src/masoniteorm/commands/CanOverrideOptionsDefault.py
+++ b/src/masoniteorm/commands/CanOverrideOptionsDefault.py
@@ -14,9 +14,9 @@ class CanOverrideOptionsDefault:
         super().__init__()
         self.overriden_default = kwargs
         for option_name, option in self.config.options.items():
-            # Cleo does not authorize _ in option name but - are authorized unfortunately -
-            # cannot be used in Python variables, so this make sure that option-a will be
-            # accessible with option_a in Python
+            # Cleo does not authorize _ in option name but - are authorized and unfortunately -
+            # cannot be used in Python variables. So underscore() is called to make sure that
+            # an option like 'option-a' will be accessible with 'option_a' in kwargs
             default = self.overriden_default.get(underscore(option_name))
             if default:
                 option.set_default(default)


### PR DESCRIPTION
```python
# for this command
        {--d|directory=app : The location of the model directory}
        {--D|migrations-directory=databases/migrations : The location of the migration directory}

# you would override it like this
MakeModelCommand(app, directory="app/models", migrations_directory="app/db/migrations")
```