### PR TITLE
Add new `shell` command to connect to database shell programs

### DIFF
--- a/src/masoniteorm/commands/Entry.py
+++ b/src/masoniteorm/commands/Entry.py
@@ -17,6 +17,7 @@ from . import (
     MigrateResetCommand,
     MakeSeedCommand,
     SeedRunCommand,
+    ShellCommand,
 )
 
 application = Application("ORM Version:", 0.1)
@@ -31,6 +32,7 @@ application.add(MigrateResetCommand())
 application.add(MigrateStatusCommand())
 application.add(MakeSeedCommand())
 application.add(SeedRunCommand())
+application.add(ShellCommand())
 
 if __name__ == "__main__":
     application.run()

--- a/src/masoniteorm/commands/ShellCommand.py
+++ b/src/masoniteorm/commands/ShellCommand.py
@@ -1,0 +1,151 @@
+import subprocess
+import shlex
+from collections import OrderedDict
+
+from ..config import load_config
+
+from .Command import Command
+
+
+class ShellCommand(Command):
+    """
+    Connect to your database interactive terminal.
+
+    shell
+        {--c|connection=default : The connection you want to use to connect to interactive terminal}
+        {--s|show=? : Display the command which will be called to connect}
+    """
+
+    shell_programs = {
+        "mysql": "mysql",
+        "postgres": "psql",
+        "sqlite": "sqlite3",
+        "mssql": "sqlcmd",
+    }
+
+    def handle(self):
+        resolver = load_config(self.option("config")).DB
+        connection = self.option("connection")
+        if connection == "default":
+            connection = resolver.get_connection_details()["default"]
+        config = resolver.get_connection_information(connection)
+        if not config.get("full_details"):
+            self.line(
+                f"<error>Connection configuration for '{connection}' not found !</error>"
+            )
+            exit(-1)
+
+        command = self.get_command(config)
+        if self.option("show"):
+            self.comment(command)
+            self.line("")
+
+        # let shlex split command in a list as it's safer
+        command_args = shlex.split(command)
+        try:
+            subprocess.run(command_args, check=True)
+        except FileNotFoundError:
+            self.line(
+                f"<error>Cannot find {config.get('full_details').get('driver')} program ! Please ensure you can call this program in your shell first.</error>"
+            )
+            exit(-1)
+
+    def get_shell_program(self, connection):
+        """Get the database shell program to run."""
+        return self.shell_programs.get(connection)
+
+    def get_command(self, config):
+        """Get the command to run as a string."""
+        driver = config.get("full_details").get("driver")
+        program = self.get_shell_program(driver)
+        try:
+            args, options = getattr(self, f"get_{driver}_args")(config)
+        except AttributeError:
+            self.line(
+                f"<error>Connecting with driver '{driver}' is not implemented !</error>"
+            )
+            exit(-1)
+        # process positional arguments
+        args = " ".join(args)
+        # process optional arguments
+        options = self.remove_empty_options(options)
+        options_string = " ".join(
+            f"{option} {value}" if value else option
+            for option, value in options.items()
+        )
+        # finally build command string
+        command = program
+        if args:
+            command += f" {args}"
+        if options_string:
+            command += f" {options_string}"
+        return command
+
+    def get_mysql_args(self, config):
+        """Get command positional arguments and options for MySQL driver."""
+        args = [config.get("database")]
+        options = OrderedDict(
+            {
+                "--host": config.get("host"),
+                "--port": config.get("port"),
+                "--user": config.get("user"),
+                "--password": config.get("password"),
+                "--default-character-set": config.get("options").get("charset"),
+            }
+        )
+        return args, options
+
+    def get_postgres_args(self, config):
+        """Get command positional arguments and options for PostgreSQL driver."""
+        args = [config.get("database")]
+        options = OrderedDict(
+            {
+                "--host": config.get("host"),
+                "--port": config.get("port"),
+                "--username": config.get("user"),
+                "--password": config.get("password"),
+            }
+        )
+        return args, options
+
+    def get_mssql_args(self, config):
+        """Get command positional arguments and options for MSSQL driver."""
+        args = []
+
+        # instance of SQL Server: -S [protocol:]server[instance_name][,port]
+        server = f"tcp:{config.get('host')}"
+        if config.get("port"):
+            server += f",{config.get('port')}"
+
+        trusted_connection = config.get("options").get("trusted_connection") == "Yes"
+        options = OrderedDict(
+            {
+                "-d": config.get("database"),
+                "-U": config.get("user"),
+                "-P": config.get("password"),
+                "-S": server,
+                "-E": trusted_connection,
+                "-t": config.get("options").get("connection_timeout"),
+            }
+        )
+        return args, options
+
+    def get_sqlite_args(self, config):
+        """Get command positional arguments and options for SQLite driver."""
+        args = [config.get("database")]
+        options = OrderedDict()
+        return args, options
+
+    def remove_empty_options(self, options):
+        """Remove empty options when value does not evaluate to True.
+        Also when value is exactly 'True' we don't want True to be passed as option value but
+        we want the option to be passed.
+        """
+        # remove empty options and remove value when option is True
+        cleaned_options = OrderedDict()
+        for key, value in options.items():
+            if value is True:
+                cleaned_options[key] = ""
+            elif value:
+                cleaned_options[key] = value
+        return cleaned_options

--- a/src/masoniteorm/commands/ShellCommand.py
+++ b/src/masoniteorm/commands/ShellCommand.py
@@ -88,6 +88,7 @@ class ShellCommand(Command):
             command += f" {options_string}"
 
         # prepare environment in which command will be run
+        # some drivers need to define env variable such as psql for specifying password
         try:
             driver_env = getattr(self, f"get_{driver}_env")(config)
         except AttributeError:
@@ -182,6 +183,9 @@ class ShellCommand(Command):
         return ["-P"]
 
     def hide_sensitive_options(self, config, command):
+        """Hide sensitive options in command string before it's displayed in the shell for
+        security reasons. All drivers can declare what options are considered sensitive, their
+        values will be then replaced by *** when displayed only."""
         cleaned_command = command
         sensitive_options = self.get_sensitive_options(config)
         for option in sensitive_options:

--- a/src/masoniteorm/commands/ShellCommand.py
+++ b/src/masoniteorm/commands/ShellCommand.py
@@ -66,12 +66,13 @@ class ShellCommand(Command):
         driver = config.get("full_details").get("driver")
         program = self.get_shell_program(driver)
         try:
-            args, options = getattr(self, f"get_{driver}_args")(config)
+            get_driver_args = getattr(self, f"get_{driver}_args")
         except AttributeError:
             self.line(
                 f"<error>Connecting with driver '{driver}' is not implemented !</error>"
             )
             exit(-1)
+        args, options = get_driver_args(config)
         # process positional arguments
         args = " ".join(args)
         # process optional arguments
@@ -106,7 +107,7 @@ class ShellCommand(Command):
                 "--port": config.get("port"),
                 "--user": config.get("user"),
                 "--password": config.get("password"),
-                "--default-character-set": config.get("options").get("charset"),
+                "--default-character-set": config.get("options", {}).get("charset"),
             }
         )
         return args, options
@@ -143,7 +144,7 @@ class ShellCommand(Command):
                 "-P": config.get("password"),
                 "-S": server,
                 "-E": trusted_connection,
-                "-t": config.get("options").get("connection_timeout"),
+                "-t": config.get("options", {}).get("connection_timeout"),
             }
         )
         return args, options

--- a/src/masoniteorm/commands/__init__.py
+++ b/src/masoniteorm/commands/__init__.py
@@ -13,3 +13,4 @@ from .MigrateStatusCommand import MigrateStatusCommand
 from .MakeMigrationCommand import MakeMigrationCommand
 from .MakeSeedCommand import MakeSeedCommand
 from .SeedRunCommand import SeedRunCommand
+from .ShellCommand import ShellCommand

--- a/tests/commands/test_shell.py
+++ b/tests/commands/test_shell.py
@@ -1,0 +1,89 @@
+import unittest
+from cleo import CommandTester
+
+from src.masoniteorm.commands import ShellCommand
+
+
+class TestShellCommand(unittest.TestCase):
+    def setUp(self):
+        self.command = ShellCommand()
+        self.command_tester = CommandTester(self.command)
+
+    def test_for_mysql(self):
+        config = {
+            "host": "localhost",
+            "database": "orm",
+            "user": "root",
+            "port": "1234",
+            "password": "secret",
+            "prefix": "",
+            "options": {"charset": "utf8mb4"},
+            "full_details": {"driver": "mysql"},
+        }
+        command, _ = self.command.get_command(config)
+        assert (
+            command
+            == "mysql orm --host localhost --port 1234 --user root --password secret --default-character-set utf8mb4"
+        )
+
+    def test_for_postgres(self):
+        config = {
+            "host": "localhost",
+            "database": "orm",
+            "user": "root",
+            "port": "1234",
+            "password": "secretpostgres",
+            "prefix": "",
+            "options": {"charset": "utf8mb4"},
+            "full_details": {"driver": "postgres"},
+        }
+        command, env = self.command.get_command(config)
+        assert command == "psql orm --host localhost --port 1234 --username root"
+        assert env.get("PGPASSWORD", "secretpostgres")
+
+    def test_for_sqlite(self):
+        config = {
+            "database": "orm.sqlite3",
+            "prefix": "",
+            "full_details": {"driver": "sqlite"},
+        }
+        command, _ = self.command.get_command(config)
+        assert command == "sqlite3 orm.sqlite3"
+
+    def test_for_mssql(self):
+        config = {
+            "host": "db.masonite.com",
+            "database": "orm",
+            "user": "root",
+            "port": "1234",
+            "password": "secretpostgres",
+            "prefix": "",
+            "options": {"charset": "utf8mb4"},
+            "full_details": {"driver": "mssql"},
+        }
+        command, _ = self.command.get_command(config)
+        assert (
+            command
+            == "sqlcmd -d orm -U root -P secretpostgres -S tcp:db.masonite.com,1234"
+        )
+
+    def test_running_command_with_sqlite(self):
+        self.command_tester.execute("-c dev")
+        assert "sqlite3" not in self.command_tester.io.fetch_output()
+        self.command_tester.execute("-c dev -s")
+        assert "sqlite3 orm.sqlite3" in self.command_tester.io.fetch_output()
+
+    def test_hiding_sensitive_options(self):
+        config = {
+            "host": "localhost",
+            "database": "orm",
+            "user": "root",
+            "port": "",
+            "password": "secret",
+            "full_details": {"driver": "mysql"},
+        }
+        command, _ = self.command.get_command(config)
+        cleaned_command = self.command.hide_sensitive_options(config, command)
+        assert (
+            cleaned_command == "mysql orm --host localhost --user root --password ***"
+        )


### PR DESCRIPTION
- Run `masonite-orm shell` to connect to database shell program of your default connection.
- Run `masonite-orm shell -c mysql` to connect to database shell program of the given connection
- Run `masonite-orm shell -s` to connect and display the command that will be called to connect.

<img width="633" alt="image" src="https://user-images.githubusercontent.com/9897999/147086421-cb4777ea-b13d-4cbe-abdd-100c08d0e0f8.png">

<img width="657" alt="image" src="https://user-images.githubusercontent.com/9897999/147086497-61401c4a-54c6-4897-afa4-e0f3312a9f8d.png">

<img width="359" alt="image" src="https://user-images.githubusercontent.com/9897999/147086573-12dbbf8b-dbc8-4c8a-b5b2-635b7e84cdc6.png">

when `-s` option is used any sensitive data will be hidden to avoid being displayed in the term (and eventually logged in bash history...or somewhere else).
![image](https://user-images.githubusercontent.com/9897999/147113405-b2ccc80e-56ba-47b5-ad5a-4fe72f119a35.png)

