### PR TITLE
Add fix for windows

### DIFF
--- a/src/masoniteorm/config.py
+++ b/src/masoniteorm/config.py
@@ -15,7 +15,9 @@ def load_config(config_path=None):
         config_path or os.getenv("DB_CONFIG_PATH", None) or "config/database"
     )
     # format path as python module if needed
-    selected_config_path = selected_config_path.replace("/", ".").rstrip(".py")
+    selected_config_path = (
+        selected_config_path.replace("/", ".").replace("\\", ".").rstrip(".py")
+    )
     config_module = pydoc.locate(selected_config_path)
     if config_module is None:
         raise ConfigurationNotFound(

--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -89,7 +89,9 @@ class Migration:
     def locate(self, file_name):
         migration_name = camelize("_".join(file_name.split("_")[4:]).replace(".py", ""))
         file_name = file_name.replace(".py", "")
-        migration_directory = self.migration_directory.replace("/", ".")
+        migration_directory = self.migration_directory.replace("/", ".").replace(
+            "\\", "."
+        )
         return locate(f"{migration_directory}.{file_name}.{migration_name}")
 
     def get_ran_migrations(self):

--- a/src/masoniteorm/seeds/Seeder.py
+++ b/src/masoniteorm/seeds/Seeder.py
@@ -6,7 +6,7 @@ class Seeder:
         self.ran_seeds = []
         self.dry = dry
         self.seed_path = seed_path
-        self.seed_module = seed_path.replace("/", ".")
+        self.seed_module = seed_path.replace("/", ".").replace("\\", ".")
 
     def call(self, *seeder_classes):
         for seeder_class in seeder_classes:


### PR DESCRIPTION
When loading Python paths to get classes, on Windows paths contains `//` and need to be processed in order to be converted to a module path.