### PR TITLE
Feat/573 - Create a seeder at same time when create a model. Instead separately

### DIFF
--- a/src/masoniteorm/commands/MakeModelCommand.py
+++ b/src/masoniteorm/commands/MakeModelCommand.py
@@ -13,10 +13,12 @@ class MakeModelCommand(Command):
     model
         {name : The name of the model}
         {--m|migration : Optionally create a migration file}
+        {--s|seeder : Optionally create a seeder file}
         {--c|create : If the migration file should create a table}
         {--t|table : If the migration file should modify an existing table}
         {--d|directory=app : The location of the model directory}
         {--D|migrations-directory=databases/migrations : The location of the migration directory}
+        {--S|seeders-directory=databases/seeds : The location of the seeders directory}
     """
 
     def handle(self):
@@ -58,3 +60,7 @@ class MakeModelCommand(Command):
                     "migration",
                     f"update_{tableize(name)}_table --table {tableize(name)} --directory {migrations_directory}",
                 )
+
+        if self.option("seeder"):
+            directory = self.option("seeders-directory")
+            self.call("seed", f"{self.argument('name')} --directory {directory}")

--- a/src/masoniteorm/commands/MakeSeedCommand.py
+++ b/src/masoniteorm/commands/MakeSeedCommand.py
@@ -35,7 +35,7 @@ class MakeSeedCommand(Command):
 
         file_name = f"{underscore(name)}.py"
         full_path = pathlib.Path(os.path.join(os.getcwd(), seed_directory, file_name))
-        
+
         path_normalized = pathlib.Path(seed_directory) / pathlib.Path(file_name)
 
         if os.path.exists(full_path):
@@ -43,5 +43,5 @@ class MakeSeedCommand(Command):
 
         with open(full_path, "w") as fp:
             fp.write(output)
-        
+
         self.info(f"Seed file created: {path_normalized}")

--- a/src/masoniteorm/commands/MakeSeedCommand.py
+++ b/src/masoniteorm/commands/MakeSeedCommand.py
@@ -34,11 +34,14 @@ class MakeSeedCommand(Command):
             output = output.replace("__SEEDER_NAME__", camelize(name))
 
         file_name = f"{underscore(name)}.py"
-        full_path = os.path.join(os.getcwd(), seed_directory, file_name)
+        full_path = pathlib.Path(os.path.join(os.getcwd(), seed_directory, file_name))
+        
+        path_normalized = pathlib.Path(seed_directory) / pathlib.Path(file_name)
+
         if os.path.exists(full_path):
-            return self.line(f"<error>{full_path} already exists.</error>")
+            return self.line(f"<error>{path_normalized} already exists.</error>")
 
         with open(full_path, "w") as fp:
             fp.write(output)
-
-        self.info(f"Seed file created: {file_name}")
+        
+        self.info(f"Seed file created: {path_normalized}")


### PR DESCRIPTION
Closes #573 

1. Ability for create seeder with model creation

Example:

`masonite-orm model Podcast -s` (Only indication to create the seeder)
`masonite-orm model Postcast -S databases/seeders` (Passing the custom directory)

2. Changing messages in case of "already exists seeder"
Before: `D:\Projetos\orm\databases\seeds\podcast_table_seeder.py`
After: `databases\seeds\podcast_table_seeder.py already exists.`

Motivation: Make model command.

@josephmancuso Let me know if you wanna tests for this feature.

Is it really necessary give the possibility to override the seeders in make model?