### PR TITLE
Rename wrong doc-string in observer stub

### DIFF
--- a/app/observers/UserObserver.py
+++ b/app/observers/UserObserver.py
@@ -29,7 +29,7 @@ class UserObserver:
         pass
 
     def saved(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "saved" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.
@@ -37,7 +37,7 @@ class UserObserver:
         pass
 
     def updating(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "updating" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.
@@ -45,7 +45,7 @@ class UserObserver:
         pass
 
     def updated(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "updated" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.
@@ -53,7 +53,7 @@ class UserObserver:
         pass
 
     def booted(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "booted" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.
@@ -61,7 +61,7 @@ class UserObserver:
         pass
 
     def booting(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "booting" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.
@@ -69,7 +69,7 @@ class UserObserver:
         pass
 
     def hydrating(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "hydrating" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.
@@ -77,7 +77,7 @@ class UserObserver:
         pass
 
     def hydrated(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "hydrated" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.
@@ -85,7 +85,7 @@ class UserObserver:
         pass
 
     def deleting(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "deleting" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.
@@ -93,7 +93,7 @@ class UserObserver:
         pass
 
     def deleted(self, clients):
-        """Handle the Clients "creating" event.
+        """Handle the Clients "deleted" event.
 
         Args:
             clients (masoniteorm.models.Model): Clients model.

--- a/src/masoniteorm/commands/stubs/observer.stub
+++ b/src/masoniteorm/commands/stubs/observer.stub
@@ -29,7 +29,7 @@ class __CLASS__Observer:
         pass
 
     def saved(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "saved" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.
@@ -37,7 +37,7 @@ class __CLASS__Observer:
         pass
 
     def updating(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "updating" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.
@@ -45,7 +45,7 @@ class __CLASS__Observer:
         pass
 
     def updated(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "updated" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.
@@ -53,7 +53,7 @@ class __CLASS__Observer:
         pass
 
     def booted(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "booted" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.
@@ -61,7 +61,7 @@ class __CLASS__Observer:
         pass
 
     def booting(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "booting" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.
@@ -69,7 +69,7 @@ class __CLASS__Observer:
         pass
 
     def hydrating(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "hydrating" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.
@@ -77,7 +77,7 @@ class __CLASS__Observer:
         pass
 
     def hydrated(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "hydrated" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.
@@ -85,7 +85,7 @@ class __CLASS__Observer:
         pass
 
     def deleting(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "deleting" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.
@@ -93,7 +93,7 @@ class __CLASS__Observer:
         pass
 
     def deleted(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "creating" event.
+        """Handle the __MODEL__ "created" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.

--- a/src/masoniteorm/commands/stubs/observer.stub
+++ b/src/masoniteorm/commands/stubs/observer.stub
@@ -93,7 +93,7 @@ class __CLASS__Observer:
         pass
 
     def deleted(self, __MODEL_VARIABLE__):
-        """Handle the __MODEL__ "created" event.
+        """Handle the __MODEL__ "deleted" event.
 
         Args:
             __MODEL_VARIABLE__ (masoniteorm.models.Model): __MODEL__ model.


### PR DESCRIPTION
This PR intended to fix the wrong doc-string when generating observer for specific model