### PR TITLE
Bump faker dep requirement to allow for using latest.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         "inflection>=0.3,<0.6",
         "pendulum>=2.1,<2.2",
-        "faker>=4.1.0,<5.0",
+        "faker>=4.1.0,<14.0",
         "cleo>=0.8.0,<0.9",
     ],
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
the only reason to use <v5 was to maintain support for Python 2, which Masonite doesn't support.

With the latest versions of Faker we can get some nice features such as method type-hinting.