### PR TITLE
Move first query builder instantiation out of init and into Model.boot()

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -216,7 +216,6 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         self._relationships = {}
         self._global_scopes = {}
 
-        self.get_builder()
         self.boot()
 
     @classmethod
@@ -278,12 +277,12 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
                 class_name = base_class.__name__
 
                 if class_name.endswith("Mixin"):
-                    getattr(self, "boot_" + class_name)(self.builder)
+                    getattr(self, "boot_" + class_name)(self.get_builder())
 
             self._booted = True
             self.observe_events(self, "booted")
 
-            self.append_passthrough(list(self.builder._macros.keys()))
+            self.append_passthrough(list(self.get_builder()._macros.keys()))
 
     def append_passthrough(self, passthrough):
         self.__passthrough__ += passthrough


### PR DESCRIPTION
This allows for logic affecting the query builder (such as db connection resource injection) to be injected by observers' "booting" events