### PR TITLE
Add `find_or_fail` on Model

### DIFF
--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -312,9 +312,9 @@ class Collection:
                 item.set_appends(self.__appends__)
 
             if hasattr(item, "serialize"):
-                exclude = []
-                if hasattr(item, "__hidden__"):
-                    exclude = item.__hidden__
+                # exclude = []
+                # if hasattr(item, "__hidden__"):
+                #     exclude = item.__hidden__
                 return item.serialize(*args, **kwargs)
             elif hasattr(item, "to_dict"):
                 return item.to_dict()

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -10,6 +10,7 @@ from ..collection import Collection
 from ..observers import ObservesEvents
 from ..scopes import TimeStampsMixin
 from ..config import load_config
+from ..exceptions import ModelNotFound
 
 """This is a magic class that will help using models like User.first() instead of having to instatiate a class like
 User().first()
@@ -308,7 +309,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         return cls
 
     @classmethod
-    def find(cls, record_id, query=False):
+    def find(cls, record_id):
         """Finds a row by the primary key ID.
 
         Arguments:
@@ -329,6 +330,23 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
                 return builder.get()
 
             return builder.first()
+
+    @classmethod
+    def find_or_fail(cls, record_id):
+        """Finds a row by the primary key ID or raise a ModelNotFound exception.
+
+        Arguments:
+            record_id {int} -- The ID of the primary key to fetch.
+
+        Returns:
+            Model
+        """
+        result = cls.find(record_id)
+
+        if not result:
+            raise ModelNotFound()
+
+        return result
 
     def first_or_new(self):
         pass

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -309,7 +309,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         return cls
 
     @classmethod
-    def find(cls, record_id):
+    def find(cls, record_id, query=False):
         """Finds a row by the primary key ID.
 
         Arguments:
@@ -332,7 +332,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             return builder.first()
 
     @classmethod
-    def find_or_fail(cls, record_id):
+    def find_or_fail(cls, record_id, query=False):
         """Finds a row by the primary key ID or raise a ModelNotFound exception.
 
         Arguments:
@@ -341,7 +341,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         Returns:
             Model
         """
-        result = cls.find(record_id)
+        result = cls.find(record_id, query)
 
         if not result:
             raise ModelNotFound()

--- a/tests/mysql/model/test_model.py
+++ b/tests/mysql/model/test_model.py
@@ -2,9 +2,9 @@ import datetime
 import json
 import os
 import unittest
-
 import pendulum
 
+from src.masoniteorm.exceptions import ModelNotFound
 from src.masoniteorm.collection import Collection
 from src.masoniteorm.models import Model
 from tests.User import User
@@ -220,6 +220,10 @@ if os.getenv("RUN_MYSQL_DATABASE", False) == "True":
 
         def test_can_find_first(self):
             profile = User.find(1)
+
+        def test_find_or_fail_raise_an_exception_if_not_exists(self):
+            with self.assertRaises(ModelNotFound):
+                User.find(100)
 
         def test_serialize_with_dirty_attribute(self):
             profile = ProfileFillAsterisk.hydrate({"name": "Joe", "id": 1})


### PR DESCRIPTION
Add query builder equivalent method for Model.

This will act as `find` but will raise a `ModelNotFound` exception if no record exists in db.

This will allow to handle those exceptions specifically, e.g. for Masonite framework.