### PR TITLE
Added .sole() method on QueryBuilder

### DIFF
--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -409,7 +409,6 @@ class Collection:
                 attributes.append(item)
         return self.__class__(attributes)
 
-    
     def where_in(self, key, args: list):
 
         attributes = []
@@ -420,12 +419,11 @@ class Collection:
                 comparison = item.get(key)
             else:
                 comparison = getattr(item, key) if hasattr(item, key) else False
-            
+
             if str(comparison) in args:
                 attributes.append(item)
 
         return self.__class__(attributes)
-
 
     def zip(self, items):
         items = self.__get_items(items)

--- a/src/masoniteorm/exceptions.py
+++ b/src/masoniteorm/exceptions.py
@@ -30,10 +30,5 @@ class InvalidUrlConfiguration(Exception):
     pass
 
 
-class NoRecordsFound(Exception):
-    pass
-
-
 class MultipleRecordsFound(Exception):
     pass
-

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -20,8 +20,13 @@ from ..expressions.expressions import (
 from ..scopes import BaseScope
 from ..schema import Schema
 from ..observers import ObservesEvents
-from ..exceptions import ModelNotFound, HTTP404, ConnectionNotRegistered, NoRecordsFound, \
-    MultipleRecordsFound
+from ..exceptions import (
+    ModelNotFound,
+    HTTP404,
+    ConnectionNotRegistered,
+    ModelNotFound,
+    MultipleRecordsFound,
+)
 from ..pagination import LengthAwarePaginator, SimplePaginator
 from .EagerRelation import EagerRelations
 from datetime import datetime, date as datetimedate, time as datetimetime
@@ -1304,7 +1309,7 @@ class QueryBuilder(ObservesEvents):
         result = self.take(2).get()
 
         if result.is_empty():
-            raise NoRecordsFound()
+            raise ModelNotFound()
 
         if result.count() > 1:
             raise MultipleRecordsFound()

--- a/tests/collection/test_collection.py
+++ b/tests/collection/test_collection.py
@@ -57,11 +57,11 @@ class TestCollection(unittest.TestCase):
                 {"id": 3, "name": "Bob"},
             ]
         )
-        self.assertEqual(len(collection.where_in("id", [1,2])), 2)
+        self.assertEqual(len(collection.where_in("id", [1, 2])), 2)
         self.assertEqual(len(collection.where_in("id", [3])), 1)
         self.assertEqual(len(collection.where_in("id", [4])), 0)
 
-        self.assertEqual(len(collection.where_in("id", ["1","2"])), 2)
+        self.assertEqual(len(collection.where_in("id", ["1", "2"])), 2)
         self.assertEqual(len(collection.where_in("id", ["3"])), 1)
         self.assertEqual(len(collection.where_in("id", ["4"])), 0)
 


### PR DESCRIPTION
Added `.sole()` method to QueryBuilder. 
Added `NoRecordsFound `Exception
Added `MultipleRecordsFound `Exception


**This method is useful to ensure that only one record matches a given criteria. If more than one record is found `MultipleRecordsFound `Exception is raised. If more no records are found then a `NoRecordsFound `Exception is raised. If only one record is found, the record is returned.**

Example usage

`book.where("title", "like", "%Olympus%").sole()`

