### PR TITLE
Added .first_where() method on QueryBuilder

### DIFF
--- a/src/masoniteorm/exceptions.py
+++ b/src/masoniteorm/exceptions.py
@@ -28,3 +28,12 @@ class ConfigurationNotFound(Exception):
 
 class InvalidUrlConfiguration(Exception):
     pass
+
+
+class NoRecordsFound(Exception):
+    pass
+
+
+class MultipleRecordsFound(Exception):
+    pass
+

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -135,6 +135,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         "find_or_fail",
         "first_or_fail",
         "first",
+        "first_where",
         "force_update",
         "from_",
         "from_raw",

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1296,7 +1296,11 @@ class QueryBuilder(ObservesEvents):
         return self.prepare_result(result)
 
     def sole(self, query=False):
+        """Gets the only record matching a given criteria.
 
+        Returns:
+            dictionary -- Returns a dictionary of results.
+        """
         result = self.take(2).get()
 
         if result.is_empty():

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -20,7 +20,8 @@ from ..expressions.expressions import (
 from ..scopes import BaseScope
 from ..schema import Schema
 from ..observers import ObservesEvents
-from ..exceptions import ModelNotFound, HTTP404, ConnectionNotRegistered
+from ..exceptions import ModelNotFound, HTTP404, ConnectionNotRegistered, NoRecordsFound, \
+    MultipleRecordsFound
 from ..pagination import LengthAwarePaginator, SimplePaginator
 from .EagerRelation import EagerRelations
 from datetime import datetime, date as datetimedate, time as datetimetime
@@ -1293,6 +1294,18 @@ class QueryBuilder(ObservesEvents):
         )
 
         return self.prepare_result(result)
+
+    def sole(self, query=False):
+
+        result = self.take(2).get()
+
+        if result.is_empty():
+            raise NoRecordsFound
+
+        if result.count() > 1:
+            raise MultipleRecordsFound
+
+        return result.first()
 
     def last(self, column=None, query=False):
         """Gets the last record, ordered by column in descendant order or primary

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1300,10 +1300,10 @@ class QueryBuilder(ObservesEvents):
         result = self.take(2).get()
 
         if result.is_empty():
-            raise NoRecordsFound
+            raise NoRecordsFound()
 
         if result.count() > 1:
-            raise MultipleRecordsFound
+            raise MultipleRecordsFound()
 
         return result.first()
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -20,8 +20,7 @@ from ..expressions.expressions import (
 from ..scopes import BaseScope
 from ..schema import Schema
 from ..observers import ObservesEvents
-from ..exceptions import ModelNotFound, HTTP404, ConnectionNotRegistered, NoRecordsFound, \
-    MultipleRecordsFound
+from ..exceptions import ModelNotFound, HTTP404, ConnectionNotRegistered
 from ..pagination import LengthAwarePaginator, SimplePaginator
 from .EagerRelation import EagerRelations
 from datetime import datetime, date as datetimedate, time as datetimetime
@@ -1295,21 +1294,15 @@ class QueryBuilder(ObservesEvents):
 
         return self.prepare_result(result)
 
-    def sole(self, query=False):
-        """Gets the only record matching a given criteria.
+    def first_where(self, column, *args):
+        """Gets the first record with the given key / value pair
 
         Returns:
             dictionary -- Returns a dictionary of results.
         """
-        result = self.take(2).get()
-
-        if result.is_empty():
-            raise NoRecordsFound()
-
-        if result.count() > 1:
-            raise MultipleRecordsFound()
-
-        return result.first()
+        if not args:
+            return self.where_not_null(column).first()
+        return self.where(column, *args).first()
 
     def last(self, column=None, query=False):
         """Gets the last record, ordered by column in descendant order or primary


### PR DESCRIPTION
Added `.first_where()` method to QueryBuilder.

This is a shortcut for `.where(....).first()` allowing this instead `.first_where(.....)`

This function is useful as it reduces the amount of repetitive code written when trying to select the first record matching a given criteria. 