### PR TITLE
Fixed string type casting/coercion from `where_in` methods

### DIFF
--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -409,10 +409,9 @@ class Collection:
                 attributes.append(item)
         return self.__class__(attributes)
 
-    def where_in(self, key, args: list):
+    def where_in(self, key, args: list) -> 'Collection':
 
         attributes = []
-        args = [str(x) for x in args]
 
         for item in self._items:
             if isinstance(item, dict):
@@ -420,8 +419,13 @@ class Collection:
             else:
                 comparison = getattr(item, key) if hasattr(item, key) else False
 
-            if str(comparison) in args:
+            if comparison in args:
                 attributes.append(item)
+
+        # Compatability patch - allow numeric strings to match integers
+        # (if all args are numeric strings and no matches were found)
+        if len(attributes) == 0 and all([isinstance(arg, str) and arg.isnumeric() for arg in args]):
+            return self.where_in(key, [int(arg) for arg in args])
 
         return self.__class__(attributes)
 

--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -422,7 +422,7 @@ class Collection:
             if comparison in args:
                 attributes.append(item)
 
-        # Compatability patch - allow numeric strings to match integers
+        # Compatibility patch - allow numeric strings to match integers
         # (if all args are numeric strings and no matches were found)
         if len(attributes) == 0 and all([isinstance(arg, str) and arg.isnumeric() for arg in args]):
             return self.where_in(key, [int(arg) for arg in args])

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -812,8 +812,7 @@ class QueryBuilder(ObservesEvents):
                 ),
             )
         else:
-            wheres = [str(x) for x in wheres]
-            self._wheres += ((QueryExpression(column, "IN", wheres)),)
+            self._wheres += ((QueryExpression(column, "IN", list(wheres))),)
         return self
 
     def get_relation(self, relationship, builder=None):
@@ -873,8 +872,7 @@ class QueryBuilder(ObservesEvents):
                 (QueryExpression(column, "NOT IN", SubSelectExpression(wheres))),
             )
         else:
-            wheres = [str(x) for x in wheres]
-            self._wheres += ((QueryExpression(column, "NOT IN", wheres)),)
+            self._wheres += ((QueryExpression(column, "NOT IN", list(wheres))),)
         return self
 
     def join(

--- a/tests/collection/test_collection.py
+++ b/tests/collection/test_collection.py
@@ -65,6 +65,47 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(len(collection.where_in("id", ["3"])), 1)
         self.assertEqual(len(collection.where_in("id", ["4"])), 0)
 
+    def test_where_in_bytes(self):
+        byte_strs = [
+            bytes('should find this', 'utf-8'),
+            bytes('and this', 'utf-8')
+        ]
+        collection = Collection(
+            [
+                {"id": 1, "name": "Joe", "bytes_val": byte_strs[0]},
+                {"id": 2, "name": "Joe", "bytes_val": byte_strs[1]},
+                {"id": 3, "name": "Bob", "bytes_val": bytes('should not find', 'utf-8')},
+                {"id": 4, "name": "Bob"},
+            ]
+        )
+        self.assertEqual(len(collection.where_in("bytes_val", byte_strs)), 2)
+        self.assertEqual(len(collection.where_in("bytes_val", [byte_strs[0]])), 1)
+
+    def test_where_in_bool(self):
+        nested_collection = Collection(
+            [
+                {"id": 1, "is_active": True},
+                {"id": 2, "is_active": True},
+                {"id": 3, "is_active": True},
+                {"id": 4}
+            ]
+        )
+        self.assertEqual(len(nested_collection.where_in("is_active", [False])), 0)
+        self.assertEqual(len(nested_collection.where_in("is_active", [True])), 3)
+        self.assertEqual(len(nested_collection.where_in("is_active", [True, False])), 3)
+        obj_collection = Collection(
+            [
+                type('',(),{'is_active': True, 'is_disabled': False}),
+                type('',(),{'is_active': False, 'is_disabled': True}),
+                type('',(),{'is_active': True, 'is_disabled': True}),
+            ]
+        )
+        self.assertEqual(len(obj_collection.where_in("is_active", [False])), 1)
+        self.assertEqual(len(obj_collection.where_in("is_active", [True])), 2)
+        self.assertEqual(len(obj_collection.where_in("is_active", [True, False])), 3)
+        self.assertEqual(len(obj_collection.where_in("nonexistent_key", [False])), 0)
+        self.assertEqual(len(obj_collection.where_in("nonexistent_key", [True])), 0)
+
     def test_pop(self):
         collection = Collection([1, 2, 3])
         self.assertEqual(collection.pop(), 3)

--- a/tests/collection/test_collection.py
+++ b/tests/collection/test_collection.py
@@ -81,31 +81,6 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(len(collection.where_in("bytes_val", byte_strs)), 2)
         self.assertEqual(len(collection.where_in("bytes_val", [byte_strs[0]])), 1)
 
-    def test_where_in_bool(self):
-        nested_collection = Collection(
-            [
-                {"id": 1, "is_active": True},
-                {"id": 2, "is_active": True},
-                {"id": 3, "is_active": True},
-                {"id": 4}
-            ]
-        )
-        self.assertEqual(len(nested_collection.where_in("is_active", [False])), 0)
-        self.assertEqual(len(nested_collection.where_in("is_active", [True])), 3)
-        self.assertEqual(len(nested_collection.where_in("is_active", [True, False])), 3)
-        obj_collection = Collection(
-            [
-                type('',(),{'is_active': True, 'is_disabled': False}),
-                type('',(),{'is_active': False, 'is_disabled': True}),
-                type('',(),{'is_active': True, 'is_disabled': True}),
-            ]
-        )
-        self.assertEqual(len(obj_collection.where_in("is_active", [False])), 1)
-        self.assertEqual(len(obj_collection.where_in("is_active", [True])), 2)
-        self.assertEqual(len(obj_collection.where_in("is_active", [True, False])), 3)
-        self.assertEqual(len(obj_collection.where_in("nonexistent_key", [False])), 0)
-        self.assertEqual(len(obj_collection.where_in("nonexistent_key", [True])), 0)
-
     def test_pop(self):
         collection = Collection([1, 2, 3])
         self.assertEqual(collection.pop(), 3)

--- a/tests/mssql/grammar/test_mssql_qmark.py
+++ b/tests/mssql/grammar/test_mssql_qmark.py
@@ -32,6 +32,11 @@ class TestMSSQLQmark(unittest.TestCase):
     def test_can_compile_where_in(self):
         mark = self.builder.where_in("id", [1, 2, 3])
 
-        sql = "SELECT * FROM [users] WHERE [users].[id] IN ('?', '?', '?')"
-        self.assertEqual(mark.to_qmark(), sql)
-        self.assertEqual(mark._bindings, ["1", "2", "3"])
+        qmark_sql = "SELECT * FROM [users] WHERE [users].[id] IN ('?', '?', '?')"
+        sql = "SELECT * FROM [users] WHERE [users].[id] IN ('1','2','3')"
+        self.assertEqual(mark.to_qmark(), qmark_sql)
+        self.assertEqual(mark._bindings, [1, 2, 3])
+        self.assertEqual(self.builder.where_in("id", [1, 2, 3]).to_sql(), sql)
+        self.builder.reset()
+        # Assert that when passed string values it generates synonymous sql
+        self.assertEqual(self.builder.where_in("id", ['1', '2', '3']).to_sql(), sql)

--- a/tests/mysql/grammar/test_mysql_qmark.py
+++ b/tests/mysql/grammar/test_mysql_qmark.py
@@ -115,7 +115,7 @@ class TestMySQLQmark(BaseQMarkTest, unittest.TestCase):
         """
         return (
             "SELECT * FROM `users` WHERE `users`.`id` IN ('?', '?', '?')",
-            ["1", "2", "3"],
+            [1, 2, 3],
         )
 
     def can_compile_where_not_null(self):


### PR DESCRIPTION
Masonite should not cast args to strings when compiling SQL, or when checking if some data exists in a collection. Rather it should use the raw data that was passed (`where()` already does this), and not make assumptions about what kind of data it is. Special cases should be handled manually, such as numeric strings matching integers.

This allows for using data such as bytes objects as args to `where_in` clauses, which will now correctly match against all database-supported data types.

This _may_ break some callers (that expect string coercion), so it should probably be considered backward-incompatible.