### PR TITLE
Fixed edge-case Collection `where_in` bugs

### DIFF
--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -416,9 +416,13 @@ class Collection:
 
         for item in self._items:
             if isinstance(item, dict):
+                if key not in item:
+                    continue
                 comparison = item.get(key)
             else:
-                comparison = getattr(item, key) if hasattr(item, key) else False
+                if not hasattr(item, key):
+                    continue
+                comparison = getattr(item, key)
 
             if str(comparison) in args:
                 attributes.append(item)

--- a/tests/collection/test_collection.py
+++ b/tests/collection/test_collection.py
@@ -65,6 +65,31 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(len(collection.where_in("id", ["3"])), 1)
         self.assertEqual(len(collection.where_in("id", ["4"])), 0)
 
+    def test_where_in_bool(self):
+        nested_collection = Collection(
+            [
+                {"id": 1, "is_active": True},
+                {"id": 2, "is_active": True},
+                {"id": 3, "is_active": True},
+                {"id": 4}
+            ]
+        )
+        self.assertEqual(len(nested_collection.where_in("is_active", [False])), 0)
+        self.assertEqual(len(nested_collection.where_in("is_active", [True])), 3)
+        self.assertEqual(len(nested_collection.where_in("is_active", [True, False])), 3)
+        obj_collection = Collection(
+            [
+                type('',(),{'is_active': True, 'is_disabled': False}),
+                type('',(),{'is_active': False, 'is_disabled': True}),
+                type('',(),{'is_active': True, 'is_disabled': True}),
+            ]
+        )
+        self.assertEqual(len(obj_collection.where_in("is_active", [False])), 1)
+        self.assertEqual(len(obj_collection.where_in("is_active", [True])), 2)
+        self.assertEqual(len(obj_collection.where_in("is_active", [True, False])), 3)
+        self.assertEqual(len(obj_collection.where_in("nonexistent_key", [False])), 0)
+        self.assertEqual(len(obj_collection.where_in("nonexistent_key", [True])), 0)
+
     def test_pop(self):
         collection = Collection([1, 2, 3])
         self.assertEqual(collection.pop(), 3)


### PR DESCRIPTION
Fixes a couple small edge-case bugs that would incorrectly match `False` & `None` values in collections when using `where_in()`