### PR TITLE
Fixed multiple bindings on _raw query methods

### DIFF
--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -704,16 +704,13 @@ class BaseGrammar:
     def get_false_column_string(self):
         return "{keyword} {column} = '0'"
 
-    def add_binding(self, binding):
-        """Adds a binding to the bindings tuple.
+    def add_binding(self, *bindings):
+        """Adds one or more bindings to the bindings tuple.
 
         Arguments:
             binding {string} -- A value to bind.
         """
-        if isinstance(binding, list):
-            self._bindings += binding
-        else:
-            self._bindings.append(binding)
+        self._bindings += bindings
 
     def column_exists(self, column):
         """Check if a column exists

--- a/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
+++ b/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
@@ -429,6 +429,14 @@ class BaseTestCaseSelectGrammar:
             self, inspect.currentframe().f_code.co_name.replace("test_", "")
         )()
         self.assertEqual(to_sql, sql)
+        
+    def test_can_compile_where_raw_and_where_with_multiple_bindings(self):
+        query = self.builder.where_raw("`age` = '?' AND `is_admin` = '?'", [18, True]).where("email", "test@example.com")
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(query.to_qmark(), sql)
+        self.assertEqual(query._bindings, [18, True, "test@example.com"])
 
     def test_can_compile_first_or_fail(self):
         to_sql = (

--- a/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
+++ b/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
@@ -429,7 +429,7 @@ class BaseTestCaseSelectGrammar:
             self, inspect.currentframe().f_code.co_name.replace("test_", "")
         )()
         self.assertEqual(to_sql, sql)
-        
+
     def test_can_compile_where_raw_and_where_with_multiple_bindings(self):
         query = self.builder.where_raw("`age` = '?' AND `is_admin` = '?'", [18, True]).where("email", "test@example.com")
         sql = getattr(

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -116,6 +116,11 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         self.builder.where_raw("`age` = '18'").to_sql()
         """
         return "SELECT * FROM [users] WHERE [users].[age] = '18'"
+    
+    def test_can_compile_where_raw_and_where_with_multiple_bindings(self):
+        query = self.builder.where_raw("[age] = '?' AND [is_admin] = '?'", [18, True]).where("email", "test@example.com")
+        self.assertEqual(query.to_qmark(), "SELECT * FROM [users] WHERE [age] = '?' AND [is_admin] = '?' AND [users].[email] = '?'")
+        self.assertEqual(query._bindings, [18, True, "test@example.com"])
 
     def can_compile_select_raw(self):
         """

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -122,6 +122,12 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         self.builder.where_raw("`age` = '18'").to_sql()
         """
         return "SELECT * FROM `users` WHERE `users`.`age` = '18'"
+    
+    def can_compile_where_raw_and_where_with_multiple_bindings(self):
+        """
+        self.builder.where_raw("`age` = '?' AND `is_admin` = '?'", [18, True]).where("email", "test@example.com")
+        """
+        return "SELECT * FROM `users` WHERE `age` = '?' AND `is_admin` = '?' AND `users`.`email` = '?'"
 
     def can_compile_select_raw(self):
         """

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -292,6 +292,11 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_where_raw(self):
         to_sql = self.builder.where_raw(""" "age" = '18'""").to_sql()
         self.assertEqual(to_sql, """SELECT * FROM "users" WHERE "age" = '18'""")
+    
+    def test_can_compile_where_raw_and_where_with_multiple_bindings(self):
+        query = self.builder.where_raw(""" "age" = '?' AND "is_admin" = '?'""", [18, True]).where("email", "test@example.com")
+        self.assertEqual(query.to_qmark(), """SELECT * FROM "users" WHERE "age" = '?' AND "is_admin" = '?' AND "users"."email" = '?'""")
+        self.assertEqual(query._bindings, [18, True, "test@example.com"])
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -283,6 +283,11 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_where_raw(self):
         to_sql = self.builder.where_raw(""" "age" = '18'""").to_sql()
         self.assertEqual(to_sql, """SELECT * FROM "users" WHERE "age" = '18'""")
+        
+    def test_can_compile_where_raw_and_where_with_multiple_bindings(self):
+        query = self.builder.where_raw(""" "age" = '?' AND "is_admin" = '?' """, [18, True]).where("email", "test@example.com")
+        self.assertEqual(query.to_qmark(), """SELECT * FROM "users" WHERE "age" = '?' AND "is_admin" = '?' AND "users"."email" = '?'""")
+        self.assertEqual(query._bindings, [18, True, "test@example.com"])
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()


### PR DESCRIPTION
When using `where_raw()` with the bindings parameter, only a max of one binding could be used. After investigating it looks like callers expected `add_binding()` to handle multiple bindings, but it only accepted one arg. This changes the implementation of `add_binding()` to accept variadic args.