### PR TITLE
adding casting to creates

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -452,7 +452,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         return Collection(data)
 
     @classmethod
-    def create(cls, dictionary=None, query=False, cast=True, **kwargs):
+    def create(cls, dictionary=None, query=False, cast=False, **kwargs):
         """Creates new records based off of a dictionary as well as data set on the model
         such as fillable values.
 


### PR DESCRIPTION
Closes #666 

Need to not cast by default for the following reason:

* we have a JSON cast. If previously people were casting to JSON when creating then this would now double cast to JSON and it will save the data in the wrong format