### PR TITLE
fixed possible migration issue

### DIFF
--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -168,6 +168,8 @@ class Migration:
         migrations = default_migrations if migration == "all" else [migration]
 
         for migration in migrations:
+            if migration.endswith(".py"):
+                migration = migration.replace(".py", "")
 
             if self.command_class:
                 self.command_class.line(


### PR DESCRIPTION
This fixes an issue where if the user specifies a migration using the `-m` flag but leaves in the `.py` at the end of the file name then they would not be able to re migrate that file. 