### PR TITLE
Allow to select migration for `migrate:reset` and `migrate:refresh` commands

### DIFF
--- a/src/masoniteorm/commands/MigrateRefreshCommand.py
+++ b/src/masoniteorm/commands/MigrateRefreshCommand.py
@@ -5,9 +5,10 @@ from .Command import Command
 
 class MigrateRefreshCommand(Command):
     """
-    Rolls back all migrations and migrates them again.
+    Rolls back migrations and migrates them again.
 
     migrate:refresh
+        {--m|migration=all : Migration's name to be refreshed}
         {--c|connection=default : The connection you want to run migrations on}
         {--d|directory=databases/migrations : The location of the migration directory}
         {--s|seed=? : Seed database after refresh. The seeder to be ran can be provided in argument}
@@ -23,7 +24,7 @@ class MigrateRefreshCommand(Command):
             config_path=self.option("config"),
         )
 
-        migration.refresh()
+        migration.refresh(self.option("migration"))
 
         self.line("")
 

--- a/src/masoniteorm/commands/MigrateResetCommand.py
+++ b/src/masoniteorm/commands/MigrateResetCommand.py
@@ -4,9 +4,10 @@ from .Command import Command
 
 class MigrateResetCommand(Command):
     """
-    Rolls back all migrations.
+    Reset migrations.
 
     migrate:reset
+        {--m|migration=all : Migration's name to be rollback}
         {--c|connection=default : The connection you want to run migrations on}
         {--d|directory=databases/migrations : The location of the migration directory}
     """
@@ -18,4 +19,4 @@ class MigrateResetCommand(Command):
             migration_directory=self.option("directory"),
             config_path=self.option("config"),
         )
-        migration.reset()
+        migration.reset(self.option("migration"))

--- a/src/masoniteorm/migrations/Migration.py
+++ b/src/masoniteorm/migrations/Migration.py
@@ -226,8 +226,11 @@ class Migration:
             "batch", self.get_last_batch_number()
         ).delete()
 
-    def reset(self):
-        for migration in self.get_all_migrations(reverse=True):
+    def reset(self, migration="all"):
+        default_migrations = self.get_all_migrations(reverse=True)
+        migrations = default_migrations if migration == "all" else [migration]
+
+        for migration in migrations:
             if self.command_class:
                 self.command_class.line(
                     f"<comment>Rolling back:</comment> <question>{migration}</question>"
@@ -253,6 +256,6 @@ class Migration:
         if self.command_class:
             self.command_class.line("")
 
-    def refresh(self):
-        self.reset()
-        self.migrate()
+    def refresh(self, migration="all"):
+        self.reset(migration)
+        self.migrate(migration)


### PR DESCRIPTION
Fix #674