### PR TITLE
Fix Collection.__eq__

### DIFF
--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -508,8 +508,7 @@ class Collection:
             yield item
 
     def __eq__(self, other):
-        if isinstance(other, Collection):
-            return other == other.all()
+        other = self.__get_items(other)
         return other == self._items
 
     def __getitem__(self, item):

--- a/tests/collection/test_collection.py
+++ b/tests/collection/test_collection.py
@@ -3,7 +3,6 @@ import unittest
 from src.masoniteorm.collection import Collection
 from src.masoniteorm.factories import Factory as factory
 from src.masoniteorm.models import Model
-
 from tests.User import User
 
 
@@ -654,3 +653,10 @@ class TestCollection(unittest.TestCase):
         collection = Collection([])
         self.assertTrue(collection._make_comparison(1, 1, "=="))
         self.assertTrue(collection._make_comparison(1, "1", "=="))
+
+    def test_eq(self):
+        collection = Collection([1, 2, 3, 4])
+        other = Collection([1, 2, 3, 4])
+        self.assertTrue(collection == other)
+        different = Collection([1, 2, 3])
+        self.assertFalse(collection == different)


### PR DESCRIPTION
...and compare other to self, not to other.

I just happened to notice this in the code while looking at something completely unrelated. So I don't know much about Masonite and I wasn't able to run the full test suite locally due to a bunch of `src.masoniteorm.exceptions.ConfigurationNotFound: ORM configuration file has not been found in config.database.` errors, but I was able to add and run a single test that fails without this change and passes with it. Hopefully CI can run the full suite.