### PR TITLE
Added exists and doesnt_exist method to QueryBuilder. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="2.11.11",
+    version="2.12.0",
     package_dir={"": "src"},
     description="The Official Masonite ORM",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="2.11.10",
+    version="2.11.11",
     package_dir={"": "src"},
     description="The Official Masonite ORM",
     long_description=long_description,

--- a/src/masoniteorm/commands/stubs/model.stub
+++ b/src/masoniteorm/commands/stubs/model.stub
@@ -1,4 +1,4 @@
-""" User Model """
+""" __CLASS__ Model """
 
 from masoniteorm.models import Model
 

--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -28,16 +28,17 @@ class QueryExpression:
 class HavingExpression:
     """A helper class to manage having expressions."""
 
-    def __init__(self, column, equality=None, value=None):
+    def __init__(self, column, equality=None, value=None, raw=False):
         self.column = column
-
-        if equality and not value:
-            value = equality
-            equality = "="
-
-        self.equality = equality
-        self.value = value
         self.value_type = "having"
+
+        if raw is False:
+            if equality and not value:
+                value = equality
+                equality = "="
+
+            self.equality = equality
+            self.value = value
 
 
 class FromTable:

--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -30,15 +30,15 @@ class HavingExpression:
 
     def __init__(self, column, equality=None, value=None, raw=False):
         self.column = column
+        self.raw = raw
+
+        if equality and not value:
+            value = equality
+            equality = "="
+
+        self.equality = equality
+        self.value = value
         self.value_type = "having"
-
-        if raw is False:
-            if equality and not value:
-                value = equality
-                equality = "="
-
-            self.equality = equality
-            self.value = value
 
 
 class FromTable:

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -437,7 +437,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
     def fill(self, attributes):
         self.__attributes__.update(attributes)
         return self
-    
+
     def fill_original(self, attributes):
         self.__original_attributes__.update(attributes)
         return self

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -435,6 +435,9 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
     def fill(self, attributes):
         self.__attributes__.update(attributes)
+        return self
+    
+    def fill_original(self, attributes):
         self.__original_attributes__.update(attributes)
         return self
 

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -158,6 +158,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         "group_by",
         "has",
         "having",
+        "having_raw",
         "increment",
         "in_random_order",
         "join_on",

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -132,6 +132,8 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         "count",
         "decrement",
         "delete",
+        "doesnt_exists",
+        "exists",
         "find_or_404",
         "find_or_fail",
         "first_or_fail",

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -438,7 +438,6 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         return self
     
     def fill_original(self, attributes):
-        print('Hiiiii')
         self.__original_attributes__.update(attributes)
         return self
 

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -438,6 +438,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         return self
     
     def fill_original(self, attributes):
+        print('Hiiiii')
         self.__original_attributes__.update(attributes)
         return self
 

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -144,7 +144,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         "count",
         "decrement",
         "delete",
-        "doesnt_exists",
+        "doesnt_exist",
         "exists",
         "find_or_404",
         "find_or_fail",

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1108,6 +1108,7 @@ class QueryBuilder(ObservesEvents):
         if model:
             model.fill(updates)
             self.observe_events(model, "updated")
+            model.fill_original(updates)
             return model
         return additional
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1104,9 +1104,9 @@ class QueryBuilder(ObservesEvents):
 
         additional.update(updates)
 
-        result = self.new_connection().query(self.to_qmark(), self._bindings)
+        self.new_connection().query(self.to_qmark(), self._bindings)
         if model:
-            model.fill(result)
+            model.fill(updates)
             self.observe_events(model, "updated")
             return model
         return additional

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -756,16 +756,16 @@ class QueryBuilder(ObservesEvents):
         self._having += ((HavingExpression(column, equality, value)),)
         return self
 
-    def having_raw(self, column):
-        """Specifying a having expression.
+    def having_raw(self, string):
+        """Specifies raw SQL that should be injected into the having expression.
 
         Arguments:
-            column {string} -- The name of the column.
+            string {string} -- The raw query string.
 
         Returns:
             self
         """
-        self._having += ((HavingExpression(column, raw=True)),)
+        self._having += ((HavingExpression(string, raw=True)),)
         return self
 
     def where_null(self, column):

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -756,6 +756,18 @@ class QueryBuilder(ObservesEvents):
         self._having += ((HavingExpression(column, equality, value)),)
         return self
 
+    def having_raw(self, column):
+        """Specifying a having expression.
+
+        Arguments:
+            column {string} -- The name of the column.
+
+        Returns:
+            self
+        """
+        self._having += ((HavingExpression(column, raw=True)),)
+        return self
+
     def where_null(self, column):
         """Specifies a where expression where the column is NULL.
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1775,6 +1775,18 @@ class QueryBuilder(ObservesEvents):
 
         return self.new_connection().query(sql, ())
 
+    def exists(self):
+        if self.first():
+            return True
+        else:
+            return False
+
+    def doesnt_exist(self):
+        if self.exists():
+            return False
+        else:
+            return True
+
     def new_from_builder(self, from_builder=None):
         """Creates a new QueryBuilder class.
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1776,12 +1776,22 @@ class QueryBuilder(ObservesEvents):
         return self.new_connection().query(sql, ())
 
     def exists(self):
+        """Determine if rows exist for the current query.
+
+        Returns:
+            Bool - True or False
+        """
         if self.first():
             return True
         else:
             return False
 
     def doesnt_exist(self):
+        """Determine if no rows exist for the current query.
+
+        Returns:
+            Bool - True or False
+        """
         if self.exists():
             return False
         else:

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -504,6 +504,7 @@ class BaseGrammar:
             column = having.column
             equality = having.equality
             value = having.value
+            raw = having.raw
 
             if not equality and not value:
                 sql_string = self.having_string()
@@ -511,7 +512,7 @@ class BaseGrammar:
                 sql_string = self.having_equality_string()
 
             sql += sql_string.format(
-                column=self._table_column_string(column),
+                column=self._table_column_string(column) if raw is False else column,
                 equality=equality,
                 value=self._compile_value(value),
             )

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -647,7 +647,7 @@ class BaseGrammar:
                 if qmark:
                     query_from_builder = value.builder.to_qmark()
                     if value.builder._bindings:
-                        self.add_binding(value.builder._bindings)
+                        self.add_binding(*value.builder._bindings)
                 else:
                     query_from_builder = value.builder.to_sql()
                 query_value = self.subquery_string().format(query=query_from_builder)

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -149,7 +149,7 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
         """
-        return "SELECT COUNT(*) as counts FROM [users] WHERE counts > 18"
+        return "SELECT COUNT(*) as counts FROM [users] HAVING counts > 18"
 
     def can_compile_count(self):
         """
@@ -300,7 +300,7 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
     def test_can_compile_having_raw(self):
         to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
-        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM [users] WHERE counts > 10")
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM [users] HAVING counts > 10")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -145,6 +145,12 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return "SELECT [users].[id], COUNT(*) FROM [users]"
 
+    def can_compile_having_raw(self):
+        """
+        self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
+        """
+        return "SELECT COUNT(*) as counts FROM [users] WHERE counts > 18"
+
     def can_compile_count(self):
         """
         self.builder.count().to_sql()
@@ -291,6 +297,10 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_where_raw(self):
         to_sql = self.builder.where_raw("[age] = '18'").to_sql()
         self.assertEqual(to_sql, "SELECT * FROM [users] WHERE [age] = '18'")
+
+    def test_can_compile_having_raw(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM [users] WHERE counts > 10")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -133,7 +133,7 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
         """
-        return "SELECT COUNT(*) as counts FROM `users` WHERE counts > 18"
+        return "SELECT COUNT(*) as counts FROM `users` HAVING counts > 18"
 
     def can_compile_select_raw(self):
         """
@@ -296,7 +296,7 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
     def test_can_compile_having_raw(self):
         to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
-        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM `users` WHERE counts > 10")
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM `users` HAVING counts > 10")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -129,6 +129,12 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return "SELECT * FROM `users` WHERE `age` = '?' AND `is_admin` = '?' AND `users`.`email` = '?'"
 
+    def can_compile_having_raw(self):
+        """
+        self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
+        """
+        return "SELECT COUNT(*) as counts FROM `users` WHERE counts > 18"
+
     def can_compile_select_raw(self):
         """
         self.builder.select_raw("COUNT(*)").to_sql()
@@ -287,6 +293,10 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_where_raw(self):
         to_sql = self.builder.where_raw("`age` = '18'").to_sql()
         self.assertEqual(to_sql, "SELECT * FROM `users` WHERE `age` = '18'")
+
+    def test_can_compile_having_raw(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM `users` WHERE counts > 10")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -121,6 +121,12 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return """SELECT * FROM "users" WHERE "users"."age" = '18'"""
 
+    def can_compile_having_raw(self):
+        """
+        self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
+        """
+        return """SELECT COUNT(*) as counts FROM "users" HAVING counts > 18"""
+
     def can_compile_select_raw(self):
         """
         self.builder.select_raw("COUNT(*)").to_sql()
@@ -292,6 +298,10 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_where_raw(self):
         to_sql = self.builder.where_raw(""" "age" = '18'""").to_sql()
         self.assertEqual(to_sql, """SELECT * FROM "users" WHERE "age" = '18'""")
+
+    def test_can_compile_having_raw(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
+        self.assertEqual(to_sql, """SELECT COUNT(*) as counts FROM "users" HAVING counts > 10""")
 
     def test_can_compile_where_raw_and_where_with_multiple_bindings(self):
         query = self.builder.where_raw(

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -239,6 +239,12 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return """SELECT SUM("users"."age") AS age FROM "users" GROUP BY "users"."age" HAVING "users"."age\""""
 
+    def can_compile_having_raw(self):
+        """
+        builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
+        """
+        return """SELECT COUNT(*) as counts FROM "users" HAVING counts > 18"""
+
     def can_compile_having_with_expression(self):
         """
         builder.sum('age').group_by('age').having('age', 10).to_sql()


### PR DESCRIPTION
Check for the existence of rows matching your query criteria. Useful alternative to performing a row count. 

Closes #687 