### PR TITLE
Added support to having_raw builder method

### DIFF
--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -28,16 +28,17 @@ class QueryExpression:
 class HavingExpression:
     """A helper class to manage having expressions."""
 
-    def __init__(self, column, equality=None, value=None):
+    def __init__(self, column, equality=None, value=None, raw=False):
         self.column = column
-
-        if equality and not value:
-            value = equality
-            equality = "="
-
-        self.equality = equality
-        self.value = value
         self.value_type = "having"
+
+        if raw is False:
+            if equality and not value:
+                value = equality
+                equality = "="
+
+            self.equality = equality
+            self.value = value
 
 
 class FromTable:

--- a/src/masoniteorm/expressions/expressions.py
+++ b/src/masoniteorm/expressions/expressions.py
@@ -30,15 +30,15 @@ class HavingExpression:
 
     def __init__(self, column, equality=None, value=None, raw=False):
         self.column = column
+        self.raw = raw
+
+        if equality and not value:
+            value = equality
+            equality = "="
+
+        self.equality = equality
+        self.value = value
         self.value_type = "having"
-
-        if raw is False:
-            if equality and not value:
-                value = equality
-                equality = "="
-
-            self.equality = equality
-            self.value = value
 
 
 class FromTable:

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -158,6 +158,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         "group_by",
         "has",
         "having",
+        "having_raw",
         "increment",
         "in_random_order",
         "join_on",

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -756,16 +756,16 @@ class QueryBuilder(ObservesEvents):
         self._having += ((HavingExpression(column, equality, value)),)
         return self
 
-    def having_raw(self, column):
-        """Specifying a having expression.
+    def having_raw(self, string):
+        """Specifies raw SQL that should be injected into the having expression.
 
         Arguments:
-            column {string} -- The name of the column.
+            string {string} -- The raw query string.
 
         Returns:
             self
         """
-        self._having += ((HavingExpression(column, raw=True)),)
+        self._having += ((HavingExpression(string, raw=True)),)
         return self
 
     def where_null(self, column):

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -756,6 +756,18 @@ class QueryBuilder(ObservesEvents):
         self._having += ((HavingExpression(column, equality, value)),)
         return self
 
+    def having_raw(self, column):
+        """Specifying a having expression.
+
+        Arguments:
+            column {string} -- The name of the column.
+
+        Returns:
+            self
+        """
+        self._having += ((HavingExpression(column, raw=True)),)
+        return self
+
     def where_null(self, column):
         """Specifies a where expression where the column is NULL.
 

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -504,6 +504,7 @@ class BaseGrammar:
             column = having.column
             equality = having.equality
             value = having.value
+            raw = having.raw
 
             if not equality and not value:
                 sql_string = self.having_string()
@@ -511,7 +512,7 @@ class BaseGrammar:
                 sql_string = self.having_equality_string()
 
             sql += sql_string.format(
-                column=self._table_column_string(column),
+                column=self._table_column_string(column) if raw is False else column,
                 equality=equality,
                 value=self._compile_value(value),
             )

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -149,7 +149,7 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
         """
-        return "SELECT COUNT(*) as counts FROM [users] WHERE counts > 18"
+        return "SELECT COUNT(*) as counts FROM [users] HAVING counts > 18"
 
     def can_compile_count(self):
         """
@@ -300,7 +300,7 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
     def test_can_compile_having_raw(self):
         to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
-        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM [users] WHERE counts > 10")
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM [users] HAVING counts > 10")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -145,6 +145,12 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return "SELECT [users].[id], COUNT(*) FROM [users]"
 
+    def can_compile_having_raw(self):
+        """
+        self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
+        """
+        return "SELECT COUNT(*) as counts FROM [users] WHERE counts > 18"
+
     def can_compile_count(self):
         """
         self.builder.count().to_sql()
@@ -291,6 +297,10 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_where_raw(self):
         to_sql = self.builder.where_raw("[age] = '18'").to_sql()
         self.assertEqual(to_sql, "SELECT * FROM [users] WHERE [age] = '18'")
+
+    def test_can_compile_having_raw(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM [users] WHERE counts > 10")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -133,7 +133,7 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
         """
-        return "SELECT COUNT(*) as counts FROM `users` WHERE counts > 18"
+        return "SELECT COUNT(*) as counts FROM `users` HAVING counts > 18"
 
     def can_compile_select_raw(self):
         """
@@ -296,7 +296,7 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
 
     def test_can_compile_having_raw(self):
         to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
-        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM `users` WHERE counts > 10")
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM `users` HAVING counts > 10")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -129,6 +129,12 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return "SELECT * FROM `users` WHERE `age` = '?' AND `is_admin` = '?' AND `users`.`email` = '?'"
 
+    def can_compile_having_raw(self):
+        """
+        self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
+        """
+        return "SELECT COUNT(*) as counts FROM `users` WHERE counts > 18"
+
     def can_compile_select_raw(self):
         """
         self.builder.select_raw("COUNT(*)").to_sql()
@@ -287,6 +293,10 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_where_raw(self):
         to_sql = self.builder.where_raw("`age` = '18'").to_sql()
         self.assertEqual(to_sql, "SELECT * FROM `users` WHERE `age` = '18'")
+
+    def test_can_compile_having_raw(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM `users` WHERE counts > 10")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -121,6 +121,12 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return """SELECT * FROM "users" WHERE "users"."age" = '18'"""
 
+    def can_compile_having_raw(self):
+        """
+        self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
+        """
+        return """SELECT COUNT(*) as counts FROM "users" HAVING counts > 18"""
+
     def can_compile_select_raw(self):
         """
         self.builder.select_raw("COUNT(*)").to_sql()
@@ -292,6 +298,10 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_where_raw(self):
         to_sql = self.builder.where_raw(""" "age" = '18'""").to_sql()
         self.assertEqual(to_sql, """SELECT * FROM "users" WHERE "age" = '18'""")
+
+    def test_can_compile_having_raw(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
+        self.assertEqual(to_sql, """SELECT COUNT(*) as counts FROM "users" HAVING counts > 10""")
 
     def test_can_compile_where_raw_and_where_with_multiple_bindings(self):
         query = self.builder.where_raw(

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -239,6 +239,12 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return """SELECT SUM("users"."age") AS age FROM "users" GROUP BY "users"."age" HAVING "users"."age\""""
 
+    def can_compile_having_raw(self):
+        """
+        builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()
+        """
+        return """SELECT COUNT(*) as counts FROM "users" HAVING counts > 18"""
+
     def can_compile_having_with_expression(self):
         """
         builder.sum('age').group_by('age').having('age', 10).to_sql()


### PR DESCRIPTION
This method will allow to use subqueries, functions and select variables inside the having expression.

```python
builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
```