### PR TITLE
Fix hardcoded `User` Model at line 1

### DIFF
--- a/src/masoniteorm/commands/stubs/model.stub
+++ b/src/masoniteorm/commands/stubs/model.stub
@@ -1,4 +1,4 @@
-""" User Model """
+""" __CLASS__ Model """
 
 from masoniteorm.models import Model
 


### PR DESCRIPTION
When creating a new Model, it was hardcoded `User Model` at line 1, and not using the new `__CLASS__` name that user chooses