### PR TITLE
Added new methods to builder (#748)

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -3,7 +3,7 @@ from datetime import datetime, date as datetimedate, time as datetimetime
 import logging
 from decimal import Decimal
 
-from inflection import tableize
+from inflection import tableize, underscore
 import inspect
 
 import pendulum
@@ -138,6 +138,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
     _booted = False
     _scopes = {}
     __primary_key__ = "id"
+    __primary_key_type__ = "int"
     __casts__ = {}
     __dates__ = []
     __hidden__ = []
@@ -282,6 +283,14 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         """
         return self.__primary_key__
 
+    def get_primary_key_type(self):
+        """Gets the primary key column type
+
+        Returns:
+            mixed
+        """
+        return self.__primary_key_type__
+
     def get_primary_key_value(self):
         """Gets the primary key value.
 
@@ -299,6 +308,17 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             raise AttributeError(
                 f"class '{name}' has no attribute {self.get_primary_key()}. Did you set the primary key correctly on the model using the __primary_key__ attribute?"
             )
+
+    def get_foreign_key(self):
+        """Gets the foreign key based on this model name.
+
+        Args:
+            relationship (str): The relationship name.
+
+        Returns:
+            str
+        """
+        return underscore(self.__class__.__name__ + "_" + self.get_primary_key())
 
     def query(self):
         return self.get_builder()

--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -133,6 +133,21 @@ class Blueprint:
         )
         return self
 
+    def unsigned_big_integer(self, column, length=32, nullable=False):
+        """Sets a column to be the unsigned big_integer representation for the table.
+
+        Arguments:
+            column {string} -- The column name.
+
+        Keyword Arguments:
+            length {int} -- The length of the column. (default: {32})
+            nullable {bool} -- Whether the column is nullable (default: {False})
+
+        Returns:
+            self
+        """
+        return self.big_integer(column, length=length, nullable=nullable).unsigned()
+
     def _compile_create(self):
         return self.grammar(creates=self._columns, table=self.table)._compile_create()
 
@@ -176,6 +191,17 @@ class Blueprint:
 
         self.primary(column)
         return self
+
+    def id(self, column="id"):
+        """Sets a column to be the auto-incrementing big integer (8-byte) primary key representation for the table.
+
+        Arguments:
+            column {string} -- The column name. Defaults to "id".
+
+        Returns:
+            self
+        """
+        return self.big_increments(column)
 
     def uuid(self, column, nullable=False, length=36):
         """Sets a column to be the UUID4 representation for the table.
@@ -840,6 +866,43 @@ class Blueprint:
             column, name=name or f"{self.table.name}_{column}_foreign"
         )
         return self
+
+    def foreign_id(self, column):
+        """Sets a column to be a unsigned big integer (8-byte) representation for a foreign ID.
+
+        Arguments:
+            column {string} -- The name of the column to reference.
+
+        Returns:
+            self
+        """
+        return self.unsigned_big_integer(column).foreign(column)
+
+    def foreign_uuid(self, column):
+        """Sets a column to be a UUID representation for a foreign UUID.
+
+        Arguments:
+            column {string} -- The name of the column to reference.
+
+        Returns:
+            self
+        """
+        return self.uuid(column).foreign(column)
+
+    def foreign_id_for(self, model, column=None):
+        """Sets a column to be a unsigned big integer (8-byte) representation for a foreign ID.
+
+        Arguments:
+            model {Model} -- The model to reference.
+
+        Returns:
+            self
+        """
+        clm = column if column else model.get_foreign_key()
+
+        return self.foreign_id(clm)\
+            if model.get_primary_key_type() == 'int'\
+            else self.foreign_uuid(column)
 
     def references(self, column):
         """Sets the other column on the foreign table that the local column will use to reference.

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -146,12 +146,12 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             [
-                "CREATE TABLE `users` (`id` INT UNSIGNED AUTO_INCREMENT NOT NULL,"
+                "CREATE TABLE `users` (`id` INT UNSIGNED AUTO_INCREMENT NOT NULL, "
                 "`id2` BIGINT UNSIGNED AUTO_INCREMENT NOT NULL, "
                 "`name` VARCHAR(255) NOT NULL, `active` TINYINT(1) NOT NULL, `email` VARCHAR(255) NOT NULL, `gender` ENUM('male', 'female') NOT NULL, "
                 "`password` VARCHAR(255) NOT NULL, `money` DECIMAL(17, 6) NOT NULL, "
                 "`admin` INT(11) NOT NULL DEFAULT 0, `option` VARCHAR(255) NOT NULL DEFAULT 'ADMIN', `remember_token` VARCHAR(255) NULL, `verified_at` TIMESTAMP NULL, "
-                "`created_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), CONSTRAINT users_email_unique UNIQUE (email))"
+                "`created_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP, `updated_at` DATETIME NULL DEFAULT CURRENT_TIMESTAMP, CONSTRAINT users_id_primary PRIMARY KEY (id), CONSTRAINT users_id2_primary PRIMARY KEY (id2), CONSTRAINT users_email_unique UNIQUE (email))"
             ],
         )
 
@@ -265,7 +265,7 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             blueprint.small_integer("small_profile_id").unsigned()
             blueprint.medium_integer("medium_profile_id").unsigned()
             blueprint.unsigned_integer("unsigned_profile_id")
-            blueprint.unsigned_big_integer("big_unsigned_profile_id")
+            blueprint.unsigned_big_integer("unsigned_big_profile_id")
 
         self.assertEqual(
             blueprint.to_sql(),

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -1,10 +1,15 @@
 import os
 import unittest
 
+from masoniteorm import Model
 from tests.integrations.config.database import DATABASES
 from src.masoniteorm.connections import MySQLConnection
 from src.masoniteorm.schema import Schema
 from src.masoniteorm.schema.platforms import MySQLPlatform
+
+
+class Discussion(Model):
+    pass
 
 
 class TestMySQLSchemaBuilder(unittest.TestCase):
@@ -92,6 +97,7 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             blueprint.integer("profile_id")
             blueprint.foreign("profile_id").references("id").on("profiles")
             blueprint.foreign_id("post_id").references("id").on("posts")
+            blueprint.foreign_id_for(Discussion).references("id").on("discussions")
 
         self.assertEqual(len(blueprint.table.added_columns), 3)
         self.assertEqual(
@@ -103,7 +109,8 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
                 "`post_id` BIGINT UNSIGNED NOT NULL, "
                 "CONSTRAINT users_name_unique UNIQUE (name), "
                 "CONSTRAINT users_profile_id_foreign FOREIGN KEY (`profile_id`) REFERENCES `profiles`(`id`), "
-                "CONSTRAINT users_profile_id_foreign FOREIGN KEY (`post_id`) REFERENCES `posts`(`id`))"
+                "CONSTRAINT users_profile_id_foreign FOREIGN KEY (`post_id`) REFERENCES `posts`(`id`)), "
+                "CONSTRAINT users_discussions_id_foreign FOREIGN KEY (`discussion_id`) REFERENCES `posts`(`id`))"
             ],
         )
 

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -142,7 +142,7 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             blueprint.timestamp("verified_at").nullable()
             blueprint.timestamps()
 
-        self.assertEqual(len(blueprint.table.added_columns), 13)
+        self.assertEqual(len(blueprint.table.added_columns), 14)
         self.assertEqual(
             blueprint.to_sql(),
             [
@@ -275,7 +275,7 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
                 "`big_profile_id` BIGINT UNSIGNED NOT NULL, "
                 "`tiny_profile_id` TINYINT UNSIGNED NOT NULL, "
                 "`small_profile_id` SMALLINT UNSIGNED NOT NULL, "
-                "`medium_profile_id` MEDIUMINT UNSIGNED NOT NULL"
+                "`medium_profile_id` MEDIUMINT UNSIGNED NOT NULL, "
                 "`unsigned_profile_id` INT UNSIGNED NOT NULL, "
                 "`unsigned_big_profile_id` BIGINT UNSIGNED NOT NULL)"
             ],

--- a/tests/mysql/schema/test_mysql_schema_builder.py
+++ b/tests/mysql/schema/test_mysql_schema_builder.py
@@ -91,6 +91,7 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             blueprint.integer("age")
             blueprint.integer("profile_id")
             blueprint.foreign("profile_id").references("id").on("profiles")
+            blueprint.foreign_id("post_id").references("id").on("posts")
 
         self.assertEqual(len(blueprint.table.added_columns), 3)
         self.assertEqual(
@@ -99,8 +100,10 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
                 "CREATE TABLE `users` (`name` VARCHAR(255) NOT NULL, "
                 "`age` INT(11) NOT NULL, "
                 "`profile_id` INT(11) NOT NULL, "
+                "`post_id` BIGINT UNSIGNED NOT NULL, "
                 "CONSTRAINT users_name_unique UNIQUE (name), "
-                "CONSTRAINT users_profile_id_foreign FOREIGN KEY (`profile_id`) REFERENCES `profiles`(`id`))"
+                "CONSTRAINT users_profile_id_foreign FOREIGN KEY (`profile_id`) REFERENCES `profiles`(`id`), "
+                "CONSTRAINT users_profile_id_foreign FOREIGN KEY (`post_id`) REFERENCES `posts`(`id`))"
             ],
         )
 
@@ -126,6 +129,7 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
     def test_can_advanced_table_creation(self):
         with self.schema.create("users") as blueprint:
             blueprint.increments("id")
+            blueprint.id("id2")
             blueprint.string("name")
             blueprint.tiny_integer("active")
             blueprint.string("email").unique()
@@ -142,7 +146,8 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
         self.assertEqual(
             blueprint.to_sql(),
             [
-                "CREATE TABLE `users` (`id` INT UNSIGNED AUTO_INCREMENT NOT NULL, "
+                "CREATE TABLE `users` (`id` INT UNSIGNED AUTO_INCREMENT NOT NULL,"
+                "`id2` BIGINT UNSIGNED AUTO_INCREMENT NOT NULL, "
                 "`name` VARCHAR(255) NOT NULL, `active` TINYINT(1) NOT NULL, `email` VARCHAR(255) NOT NULL, `gender` ENUM('male', 'female') NOT NULL, "
                 "`password` VARCHAR(255) NOT NULL, `money` DECIMAL(17, 6) NOT NULL, "
                 "`admin` INT(11) NOT NULL DEFAULT 0, `option` VARCHAR(255) NOT NULL DEFAULT 'ADMIN', `remember_token` VARCHAR(255) NULL, `verified_at` TIMESTAMP NULL, "
@@ -259,6 +264,8 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
             blueprint.tiny_integer("tiny_profile_id").unsigned()
             blueprint.small_integer("small_profile_id").unsigned()
             blueprint.medium_integer("medium_profile_id").unsigned()
+            blueprint.unsigned_integer("unsigned_profile_id")
+            blueprint.unsigned_big_integer("big_unsigned_profile_id")
 
         self.assertEqual(
             blueprint.to_sql(),
@@ -268,7 +275,9 @@ class TestMySQLSchemaBuilder(unittest.TestCase):
                 "`big_profile_id` BIGINT UNSIGNED NOT NULL, "
                 "`tiny_profile_id` TINYINT UNSIGNED NOT NULL, "
                 "`small_profile_id` SMALLINT UNSIGNED NOT NULL, "
-                "`medium_profile_id` MEDIUMINT UNSIGNED NOT NULL)"
+                "`medium_profile_id` MEDIUMINT UNSIGNED NOT NULL"
+                "`unsigned_profile_id` INT UNSIGNED NOT NULL, "
+                "`unsigned_big_profile_id` BIGINT UNSIGNED NOT NULL)"
             ],
         )
 


### PR DESCRIPTION
The following methods have been implemented from #748:
- `unsigned_big_integer`
- `id`
- `foreign_id`
- `foreign_id_for`
- `foreign_uuid`

