### PR TITLE
Fixed JSON Cast should always return a string

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -58,12 +58,17 @@ class JsonCast:
     """Casts a value to JSON"""
 
     def get(self, value):
-        if isinstance(value, dict) or isinstance(value, list):
-            return value
+        if not isinstance(value, str):
+            return json.dumps(value)
 
-        return json.loads(value)
+        return value
 
     def set(self, value):
+        if isinstance(value, str):
+            # make sure the string is valid JSON
+            json.loads(value)
+            return value
+
         return json.dumps(value)
 
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from src.masoniteorm.models import Model
 import pendulum
@@ -89,14 +90,15 @@ class TestModels(unittest.TestCase):
         model = ModelTest.hydrate(
             {
                 "is_vip": 1,
-                "payload": '{"key": "value"}',
+                "payload": '["item1", "item2"]',
                 "x": True,
                 "f": "10.5",
                 "d": 3.14,
             }
         )
 
-        self.assertEqual(type(model.payload), dict)
+        self.assertEqual(type(model.payload), str)
+        self.assertEqual(type(json.loads(model.payload)), list)
         self.assertEqual(type(model.x), int)
         self.assertEqual(type(model.f), float)
         self.assertEqual(type(model.is_vip), bool)
@@ -110,7 +112,8 @@ class TestModels(unittest.TestCase):
             {"is_vip": 1, "payload": dictcasttest, "x": True, "f": "10.5"}
         )
 
-        self.assertEqual(type(model.payload), dict)
+        self.assertEqual(type(model.payload), str)
+        self.assertEqual(type(json.loads(model.payload)), dict)
         self.assertEqual(type(model.x), int)
         self.assertEqual(type(model.f), float)
         self.assertEqual(type(model.is_vip), bool)


### PR DESCRIPTION
This fixes the issue where a valid JSON string was not returned if the value being cast was a dict or list.
Added validation (as a valid JSON structure) of the value if it is a string 