### PR TITLE
Fix/issue 772

### DIFF
--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -2089,7 +2089,6 @@ class QueryBuilder(ObservesEvents):
         for name, scope in self._global_scopes.get(self._action, {}).items():
             scope(self)
 
-        grammar = self.get_grammar()
         sql = grammar.compile(self._action, qmark=True).to_sql()
 
         self._bindings = grammar._bindings

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -464,7 +464,12 @@ class QueryBuilder(ObservesEvents):
         model = None
         self.set_action("bulk_create")
 
-        self._creates = creates
+        sorted_creates = []
+        # sort the dicts by key so the values inserted align
+        # with the correct column
+        for unsorted_dict in creates:
+            sorted_creates.append(dict(sorted(unsorted_dict.items())))
+        self._creates = sorted_creates
 
         if self._model:
             model = self._model

--- a/tests/mssql/grammar/test_mssql_insert_grammar.py
+++ b/tests/mssql/grammar/test_mssql_insert_grammar.py
@@ -17,10 +17,10 @@ class TestMySQLInsertGrammar(unittest.TestCase):
 
     def test_can_compile_bulk_create(self):
         to_sql = self.builder.bulk_create(
-            [{"name": "Joe"}, {"name": "Bill"}, {"name": "John"}], query=True
+            [{"name": "Joe", "age": 5}, {"age": 35, "name": "Bill"}, {"name": "John", "age": 10}], query=True
         ).to_sql()
 
-        sql = "INSERT INTO [users] ([name]) VALUES ('Joe'), ('Bill'), ('John')"
+        sql = "INSERT INTO [users] ([age], [name]) VALUES ('5', 'Joe'), ('35', 'Bill'), ('10', 'John')"
         self.assertEqual(to_sql, sql)
 
     def test_can_compile_bulk_create_qmark(self):

--- a/tests/mssql/grammar/test_mssql_insert_grammar.py
+++ b/tests/mssql/grammar/test_mssql_insert_grammar.py
@@ -17,6 +17,7 @@ class TestMySQLInsertGrammar(unittest.TestCase):
 
     def test_can_compile_bulk_create(self):
         to_sql = self.builder.bulk_create(
+            # These keys are intentionally out of order to show column to value alignment works
             [{"name": "Joe", "age": 5}, {"age": 35, "name": "Bill"}, {"name": "John", "age": 10}], query=True
         ).to_sql()
 

--- a/tests/mysql/grammar/test_mysql_insert_grammar.py
+++ b/tests/mysql/grammar/test_mysql_insert_grammar.py
@@ -27,7 +27,7 @@ class BaseInsertGrammarTest:
 
     def test_can_compile_bulk_create(self):
         to_sql = self.builder.bulk_create(
-            [{"name": "Joe"}, {"name": "Bill"}, {"name": "John"}], query=True
+            [{"name": "Joe", "age": 5}, {"age": 35, "name": "Bill"}, {"name": "John", "age": 10}], query=True
         ).to_sql()
 
         sql = getattr(
@@ -83,13 +83,13 @@ class TestMySQLUpdateGrammar(BaseInsertGrammarTest, unittest.TestCase):
         """
         self.builder.create(name="Joe").to_sql()
         """
-        return """INSERT INTO `users` (`name`) VALUES ('Joe'), ('Bill'), ('John')"""
+        return """INSERT INTO `users` (`age`, `name`) VALUES ('5', 'Joe'), ('35', 'Bill'), ('10', 'John')"""
 
     def can_compile_bulk_create_multiple(self):
         """
         self.builder.create(name="Joe").to_sql()
         """
-        return """INSERT INTO `users` (`name`, `active`) VALUES ('Joe', '1'), ('Bill', '1'), ('John', '1')"""
+        return """INSERT INTO `users` (`active`, `name`) VALUES ('1', 'Joe'), ('1', 'Bill'), ('1', 'John')"""
 
     def can_compile_bulk_create_qmark(self):
         """

--- a/tests/mysql/grammar/test_mysql_insert_grammar.py
+++ b/tests/mysql/grammar/test_mysql_insert_grammar.py
@@ -27,6 +27,7 @@ class BaseInsertGrammarTest:
 
     def test_can_compile_bulk_create(self):
         to_sql = self.builder.bulk_create(
+            # These keys are intentionally out of order to show column to value alignment works
             [{"name": "Joe", "age": 5}, {"age": 35, "name": "Bill"}, {"name": "John", "age": 10}], query=True
         ).to_sql()
 

--- a/tests/postgres/grammar/test_insert_grammar.py
+++ b/tests/postgres/grammar/test_insert_grammar.py
@@ -27,6 +27,7 @@ class BaseInsertGrammarTest:
 
     def test_can_compile_bulk_create(self):
         to_sql = self.builder.bulk_create(
+            # These keys are intentionally out of order to show column to value alignment works
             [{"name": "Joe", "age": 5}, {"age": 35, "name": "Bill"}, {"name": "John", "age": 10}], query=True
         ).to_sql()
 

--- a/tests/postgres/grammar/test_insert_grammar.py
+++ b/tests/postgres/grammar/test_insert_grammar.py
@@ -27,7 +27,7 @@ class BaseInsertGrammarTest:
 
     def test_can_compile_bulk_create(self):
         to_sql = self.builder.bulk_create(
-            [{"name": "Joe"}, {"name": "Bill"}, {"name": "John"}], query=True
+            [{"name": "Joe", "age": 5}, {"age": 35, "name": "Bill"}, {"name": "John", "age": 10}], query=True
         ).to_sql()
 
         sql = getattr(
@@ -68,7 +68,7 @@ class TestPostgresUpdateGrammar(BaseInsertGrammarTest, unittest.TestCase):
         """
         self.builder.create(name="Joe").to_sql()
         """
-        return """INSERT INTO "users" ("name") VALUES ('Joe'), ('Bill'), ('John') RETURNING *"""
+        return """INSERT INTO "users" ("age", "name") VALUES ('5', 'Joe'), ('35', 'Bill'), ('10', 'John') RETURNING *"""
 
     def can_compile_bulk_create_qmark(self):
         """

--- a/tests/sqlite/grammar/test_sqlite_insert_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_insert_grammar.py
@@ -27,7 +27,7 @@ class BaseInsertGrammarTest:
 
     def test_can_compile_bulk_create(self):
         to_sql = self.builder.bulk_create(
-            [{"name": "Joe"}, {"name": "Bill"}, {"name": "John"}], query=True
+            [{"name": "Joe", "age": 5}, {"age": 35, "name": "Bill"}, {"name": "John", "age": 10}], query=True
         ).to_sql()
 
         sql = getattr(
@@ -83,13 +83,13 @@ class TestSqliteUpdateGrammar(BaseInsertGrammarTest, unittest.TestCase):
         """
         self.builder.create(name="Joe").to_sql()
         """
-        return """INSERT INTO "users" ("name") VALUES ('Joe'), ('Bill'), ('John')"""
+        return """INSERT INTO "users" ("age", "name") VALUES ('5', 'Joe'), ('35', 'Bill'), ('10', 'John')"""
 
     def can_compile_bulk_create_multiple(self):
         """
         self.builder.create(name="Joe").to_sql()
         """
-        return """INSERT INTO "users" ("name", "active") VALUES ('Joe', '1'), ('Bill', '1'), ('John', '1')"""
+        return """INSERT INTO "users" ("active", "name") VALUES ('1', 'Joe'), ('1', 'Bill'), ('1', 'John')"""
 
     def can_compile_bulk_create_qmark(self):
         """

--- a/tests/sqlite/grammar/test_sqlite_insert_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_insert_grammar.py
@@ -27,6 +27,7 @@ class BaseInsertGrammarTest:
 
     def test_can_compile_bulk_create(self):
         to_sql = self.builder.bulk_create(
+            # These keys are intentionally out of order to show column to value alignment works
             [{"name": "Joe", "age": 5}, {"age": 35, "name": "Bill"}, {"name": "John", "age": 10}], query=True
         ).to_sql()
 


### PR DESCRIPTION
This fixes #772  by sorting the dicts passed in prior to passing them to grammar compilation .

This means that regardless of the order of the values in an input dict they will always align with the correct column to insert.
