### PR TITLE
Fixed wrong select structure when using having and order by

### DIFF
--- a/src/masoniteorm/query/grammars/MSSQLGrammar.py
+++ b/src/masoniteorm/query/grammars/MSSQLGrammar.py
@@ -10,7 +10,6 @@ class MSSQLGrammar(BaseGrammar):
         "MIN": "MIN",
         "AVG": "AVG",
         "COUNT": "COUNT",
-        "AVG": "AVG",
     }
 
     join_keywords = {
@@ -37,7 +36,7 @@ class MSSQLGrammar(BaseGrammar):
         return "SELECT {columns}"
 
     def select_format(self):
-        return "SELECT {limit} {columns} FROM {table} {lock} {joins} {wheres} {group_by} {order_by} {offset} {having}"
+        return "SELECT {limit} {columns} FROM {table} {lock} {joins} {wheres} {group_by} {having} {order_by} {offset}"
 
     def update_format(self):
         return "UPDATE {table} SET {key_equals} {wheres}"

--- a/src/masoniteorm/query/grammars/MySQLGrammar.py
+++ b/src/masoniteorm/query/grammars/MySQLGrammar.py
@@ -10,7 +10,6 @@ class MySQLGrammar(BaseGrammar):
         "MIN": "MIN",
         "AVG": "AVG",
         "COUNT": "COUNT",
-        "AVG": "AVG",
     }
 
     join_keywords = {
@@ -50,7 +49,7 @@ class MySQLGrammar(BaseGrammar):
     locks = {"share": "LOCK IN SHARE MODE", "update": "FOR UPDATE"}
 
     def select_format(self):
-        return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {order_by} {limit} {offset} {having} {lock}"
+        return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {having} {order_by} {limit} {offset} {lock}"
 
     def select_no_table(self):
         return "SELECT {columns} {lock}"

--- a/src/masoniteorm/query/grammars/PostgresGrammar.py
+++ b/src/masoniteorm/query/grammars/PostgresGrammar.py
@@ -11,7 +11,6 @@ class PostgresGrammar(BaseGrammar):
         "MIN": "MIN",
         "AVG": "AVG",
         "COUNT": "COUNT",
-        "AVG": "AVG",
     }
 
     join_keywords = {
@@ -38,7 +37,7 @@ class PostgresGrammar(BaseGrammar):
         return "SELECT {columns} {lock}"
 
     def select_format(self):
-        return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {order_by} {limit} {offset} {having} {lock}"
+        return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {having} {order_by} {limit} {offset} {lock}"
 
     def update_format(self):
         return "UPDATE {table} SET {key_equals} {wheres}"

--- a/src/masoniteorm/query/grammars/SQLiteGrammar.py
+++ b/src/masoniteorm/query/grammars/SQLiteGrammar.py
@@ -11,7 +11,6 @@ class SQLiteGrammar(BaseGrammar):
         "MIN": "MIN",
         "AVG": "AVG",
         "COUNT": "COUNT",
-        "AVG": "AVG",
     }
 
     join_keywords = {
@@ -35,7 +34,7 @@ class SQLiteGrammar(BaseGrammar):
     locks = {"share": "", "update": ""}
 
     def select_format(self):
-        return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {order_by} {limit} {offset} {having} {lock}"
+        return "SELECT {columns} FROM {table} {joins} {wheres} {group_by} {having} {order_by} {limit} {offset} {lock}"
 
     def select_no_table(self):
         return "SELECT {columns} {lock}"

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -246,6 +246,12 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return "SELECT SUM([users].[age]) AS age FROM [users] GROUP BY [users].[age] HAVING [users].[age]"
 
+    def can_compile_having_order(self):
+        """
+        builder.sum('age').group_by('age').having('age').order_by('age', 'desc').to_sql()
+        """
+        return "SELECT SUM([users].[age]) AS age FROM [users] GROUP BY [users].[age] HAVING [users].[age] ORDER [users].[age] DESC"
+
     def can_compile_between(self):
         """
         builder.between('age', 18, 21).to_sql()
@@ -301,6 +307,11 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_having_raw(self):
         to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
         self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM [users] HAVING counts > 10")
+
+    def test_can_compile_having_raw_order(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").order_by_raw(
+            'counts DESC').to_sql()
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM [users] HAVING counts > 10 ORDER BY counts DESC")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -248,6 +248,12 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return "SELECT SUM(`users`.`age`) AS age FROM `users` GROUP BY `users`.`age` HAVING `users`.`age`"
 
+    def can_compile_having_order(self):
+        """
+        builder.sum('age').group_by('age').having('age').order_by('age', 'desc').to_sql()
+        """
+        return "SELECT SUM(`users`.`age`) AS age FROM `users` GROUP BY `users`.`age` HAVING `users`.`age` ORDER `users`.`age` DESC"
+
     def can_compile_having_with_expression(self):
         """
         builder.sum('age').group_by('age').having('age', 10).to_sql()
@@ -297,6 +303,10 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_having_raw(self):
         to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
         self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM `users` HAVING counts > 10")
+
+    def test_can_compile_having_raw_order(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").order_by_raw('counts DESC').to_sql()
+        self.assertEqual(to_sql, "SELECT COUNT(*) as counts FROM `users` HAVING counts > 10 ORDER BY counts DESC")
 
     def test_can_compile_select_raw(self):
         to_sql = self.builder.select_raw("COUNT(*)").to_sql()

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -247,6 +247,12 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return """SELECT SUM("users"."age") AS age FROM "users" GROUP BY "users"."age" HAVING "users"."age\""""
 
+    def can_compile_having_order(self):
+        """
+        builder.sum('age').group_by('age').having('age').order_by('age', 'desc').to_sql()
+        """
+        return """SELECT SUM("users"."age") AS age FROM "users" GROUP BY "users"."age" HAVING "users"."age" ORDER "users"."age" DESC"""
+
     def can_compile_having_with_expression(self):
         """
         builder.sum('age').group_by('age').having('age', 10).to_sql()
@@ -302,6 +308,10 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
     def test_can_compile_having_raw(self):
         to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").to_sql()
         self.assertEqual(to_sql, """SELECT COUNT(*) as counts FROM "users" HAVING counts > 10""")
+
+    def test_can_compile_having_raw_order(self):
+        to_sql = self.builder.select_raw("COUNT(*) as counts").having_raw("counts > 10").order_by_raw('counts DESC').to_sql()
+        self.assertEqual(to_sql, """SELECT COUNT(*) as counts FROM "users" HAVING counts > 10 ORDER BY counts DESC""")
 
     def test_can_compile_where_raw_and_where_with_multiple_bindings(self):
         query = self.builder.where_raw(

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -239,6 +239,12 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         """
         return """SELECT SUM("users"."age") AS age FROM "users" GROUP BY "users"."age" HAVING "users"."age\""""
 
+    def can_compile_having_order(self):
+        """
+        builder.sum('age').group_by('age').having('age').order_by('age', 'desc').to_sql()
+        """
+        return """SELECT SUM("users"."age") AS age FROM "users" GROUP BY "users"."age" HAVING "users"."age\" ORDER "users"."age" DESC"""
+
     def can_compile_having_raw(self):
         """
         builder.select_raw("COUNT(*) as counts").having_raw("counts > 18").to_sql()


### PR DESCRIPTION
Hi,

This pull request is to fix a problem in the structure of select when using having and order.

ORDER, HAVING to HAVING, ORDER

```python
QueryBuilder().table("user").where_null("deletedat").group_by("age").having_raw("age > 2").order_by("age")
```
Current:
```sql
SELECT * FROM `user` WHERE `user`.`deletedat` IS NULL GROUP BY `user`.`age` ORDER BY `age` ASC HAVING age > 2
```
Should be:
```sql
SELECT * FROM `user` WHERE `user`.`deletedat` IS NULL GROUP BY `user`.`age` HAVING age > 2 ORDER BY `age` ASC
```

Source: https://www.w3schools.com/sql/sql_having.asp