### PR TITLE
Connection config loading

### DIFF
--- a/src/masoniteorm/commands/MigrateRefreshCommand.py
+++ b/src/masoniteorm/commands/MigrateRefreshCommand.py
@@ -33,11 +33,11 @@ class MigrateRefreshCommand(Command):
         if self.option("seed") == "null":
             self.call(
                 "seed:run",
-                f"None --directory {self.option('seed-directory')} --connection {self.option('connection', 'default')}",
+                f"None --directory {self.option('seed-directory')} --connection {self.option('connection')}",
             )
 
         elif self.option("seed"):
             self.call(
                 "seed:run",
-                f"{self.option('seed')} --directory {self.option('seed-directory')} --connection {self.option('connection', 'default')}",
+                f"{self.option('seed')} --directory {self.option('seed-directory')} --connection {self.option('connection')}",
             )

--- a/src/masoniteorm/config.py
+++ b/src/masoniteorm/config.py
@@ -11,9 +11,12 @@ def load_config(config_path=None):
         1. try to load from DB_CONFIG_PATH environment variable
         2. else try to load from default config_path: config/database
     """
-    selected_config_path = (
-        config_path or os.getenv("DB_CONFIG_PATH", None) or "config/database"
-    )
+
+    if not os.getenv("DB_CONFIG_PATH", None):
+        os.environ['DB_CONFIG_PATH'] = config_path or "config/database"
+    
+    selected_config_path = os.environ['DB_CONFIG_PATH']
+    
     # format path as python module if needed
     selected_config_path = (
         selected_config_path.replace("/", ".").replace("\\", ".").rstrip(".py")

--- a/src/masoniteorm/config.py
+++ b/src/masoniteorm/config.py
@@ -13,10 +13,10 @@ def load_config(config_path=None):
     """
 
     if not os.getenv("DB_CONFIG_PATH", None):
-        os.environ['DB_CONFIG_PATH'] = config_path or "config/database"
-    
-    selected_config_path = os.environ['DB_CONFIG_PATH']
-    
+        os.environ["DB_CONFIG_PATH"] = config_path or "config/database"
+
+    selected_config_path = os.environ["DB_CONFIG_PATH"]
+
     # format path as python module if needed
     selected_config_path = (
         selected_config_path.replace("/", ".").replace("\\", ".").rstrip(".py")

--- a/src/masoniteorm/observers/ObservesEvents.py
+++ b/src/masoniteorm/observers/ObservesEvents.py
@@ -16,14 +16,12 @@ class ObservesEvents:
 
     @classmethod
     def without_events(cls):
-        """Sets __has_events__ attribute on model to false.
-        """
+        """Sets __has_events__ attribute on model to false."""
         cls.__has_events__ = False
         return cls
 
     @classmethod
     def with_events(cls):
-        """Sets __has_events__ attribute on model to True.
-        """
+        """Sets __has_events__ attribute on model to True."""
         cls.__has_events__ = False
         return cls

--- a/src/masoniteorm/schema/Blueprint.py
+++ b/src/masoniteorm/schema/Blueprint.py
@@ -900,9 +900,11 @@ class Blueprint:
         """
         clm = column if column else model.get_foreign_key()
 
-        return self.foreign_id(clm)\
-            if model.get_primary_key_type() == 'int'\
+        return (
+            self.foreign_id(clm)
+            if model.get_primary_key_type() == "int"
             else self.foreign_uuid(column)
+        )
 
     def references(self, column):
         """Sets the other column on the foreign table that the local column will use to reference.

--- a/src/masoniteorm/schema/Schema.py
+++ b/src/masoniteorm/schema/Schema.py
@@ -287,8 +287,7 @@ class Schema:
         return bool(self.new_connection().query(sql, ()))
 
     def get_schema(self):
-        """Gets the schema set on the migration class
-        """
+        """Gets the schema set on the migration class"""
         return self.schema or self.get_connection_information().get("full_details").get(
             "schema"
         )


### PR DESCRIPTION
@josephmancuso @girardinsamuel 
Closes #793 
Closes #794 

**1. Config Module**
> Maybe a second solution is cascading the `config_path` variable 

Changing the way of `config_path` is loaded in `load()` module.

For the first load from the environment, it if is None, use the custom or default value and finally define the value back to DB_CONFIG_PATH environment ( which is first loaded in function call ).

Don't cascading the `config_path` value cause some classes already use the connection class previously loaded on top of modules.

**Schema:** https://github.com/MasoniteFramework/orm/blob/2.0/src/masoniteorm/schema/Schema.py#L89
**ConnectionFactory:** https://github.com/MasoniteFramework/orm/blob/2.0/src/masoniteorm/connections/ConnectionFactory.py#L38

**2. Arguments in Seed Run**
Removing the second parameter in `self.option()` function, it already uses the default from the definition.