### PR TITLE
added delete_quietly method on Model

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -1066,7 +1066,9 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         Returns:
             self
         """
-        return self.without_events().delete()
+        delete = self.without_events().where(self.get_primary_key(), self.get_primary_key_value()).delete()
+        self.with_events()
+        return delete
 
     def attach_related(self, relation, related_record):
         related = getattr(self.__class__, relation)

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -1053,6 +1053,21 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         return related.detach(self, related_record)
 
+    def delete_quietly(self):
+        """This method calls the delete method on a model without firing the delete & deleting observer events.
+        Instead of calling:
+
+        User().delete(...)
+
+        you can use this:
+
+        User.delete_quietly(...)
+
+        Returns:
+            self
+        """
+        return self.without_events().delete()
+
     def attach_related(self, relation, related_record):
         related = getattr(self.__class__, relation)
 

--- a/src/masoniteorm/observers/ObservesEvents.py
+++ b/src/masoniteorm/observers/ObservesEvents.py
@@ -23,5 +23,5 @@ class ObservesEvents:
     @classmethod
     def with_events(cls):
         """Sets __has_events__ attribute on model to True."""
-        cls.__has_events__ = False
+        cls.__has_events__ = True
         return cls


### PR DESCRIPTION
This method calls the delete method on a model without firing the delete & deleting observer events.
Instead of calling:

User().delete(...)

you can use this:

User.delete_quietly(...)