### PR TITLE
added save_quietly method on Model

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -1053,6 +1053,23 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         return related.detach(self, related_record)
 
+    def save_quietly(self):
+        """This method calls the save method on a model without firing the saved & saving observer events. Saved/Saving
+        are toggled back on once save_quietly has been ran.
+
+        Instead of calling:
+
+        User().save(...)
+
+        you can use this:
+
+        User.save_quietly(...)
+
+        Returns:
+            self
+        """
+        return self.without_events().save().with_events()
+
     def attach_related(self, relation, related_record):
         related = getattr(self.__class__, relation)
 

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -1065,7 +1065,10 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         User.save_quietly(...)
         """
-        return self.without_events().save().with_events()
+        self.without_events()
+        saved = self.save()
+        self.with_events()
+        return saved
 
     def delete_quietly(self):
         """This method calls the delete method on a model without firing the delete & deleting observer events.


### PR DESCRIPTION
This method calls the save method on a model without firing the saved & saving observer events. Saved/Saving are toggled back on once save_quietly has been ran.

Instead of calling:

User().save(...)

you can use this:

User.save_quietly(...)