### PR TITLE
JSONCast Force conversion to str for unhandled types

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -72,7 +72,7 @@ class JsonCast:
             json.loads(value)
             return value
 
-        return json.dumps(value)
+        return json.dumps(value, default=str)
 
 
 class IntCast:


### PR DESCRIPTION
This fixes issues when casting types like Decimal to JSON throwing a TypeError
