### PR TITLE
Adds function increment_each. This allows specifying multiple columns to increment by

### DIFF
--- a/src/masoniteorm/exceptions.py
+++ b/src/masoniteorm/exceptions.py
@@ -32,3 +32,8 @@ class InvalidUrlConfiguration(Exception):
 
 class MultipleRecordsFound(Exception):
     pass
+
+
+class InvalidArgument(Exception):
+    pass
+

--- a/src/masoniteorm/exceptions.py
+++ b/src/masoniteorm/exceptions.py
@@ -36,4 +36,3 @@ class MultipleRecordsFound(Exception):
 
 class InvalidArgument(Exception):
     pass
-

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -200,6 +200,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             "having",
             "having_raw",
             "increment",
+            "increment_each",
             "in_random_order",
             "join_on",
             "join",

--- a/src/masoniteorm/models/Model.pyi
+++ b/src/masoniteorm/models/Model.pyi
@@ -293,6 +293,18 @@ class Model:
             self
         """
         pass
+
+    def increment_each(columns: list):
+        """Increments a column's value.
+
+        Arguments:
+            columns {list} -- List of dictionaries containing key column and increment value.
+
+        Returns:
+            self
+        """
+        pass
+
     def in_random_order():
         """Puts Query results in random order"""
         pass

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1500,7 +1500,6 @@ class QueryBuilder(ObservesEvents):
             self
         """
         model = None
-        id_key = "id"
         id_value = None
 
         additional = {}
@@ -1516,7 +1515,6 @@ class QueryBuilder(ObservesEvents):
             self.observe_events(model, "updating")
 
         columns_count: int = len(columns)
-        processed_results: dict = {}
 
         for index, column in enumerate(columns, start=1):
             value = str(list(column.values())[0])
@@ -1536,11 +1534,6 @@ class QueryBuilder(ObservesEvents):
 
             if index == columns_count:
                 results = self.new_connection().query(self.to_qmark(), self._bindings)
-                for column in columns:
-                    column = str(list(column.keys())[0])
-                    #processed_results = {**processed_results, **self.get_processor().get_column_value(
-                    #    self, column, results, id_key, id_value
-                    #)}
         if model:
             return model.fresh()
         else:

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1497,7 +1497,6 @@ class QueryBuilder(ObservesEvents):
             self
         """
         model = None
-        id_value = None
 
         additional = {}
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1417,10 +1417,7 @@ class QueryBuilder(ObservesEvents):
                 updates = {
                     attr: value
                     for attr, value in updates.items()
-                    if (
-                            value is None
-                            or model.__original_attributes__.get(attr, None) != value
-                    )
+                    if (value is None or model.__original_attributes__.get(attr, None) != value)
                 }
 
             # Do not execute query if no changes
@@ -1533,7 +1530,7 @@ class QueryBuilder(ObservesEvents):
             self.set_action("update")
 
             if index == columns_count:
-                results = self.new_connection().query(self.to_qmark(), self._bindings)
+                self.new_connection().query(self.to_qmark(), self._bindings)
         if model:
             return model.fresh()
         else:

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1503,7 +1503,6 @@ class QueryBuilder(ObservesEvents):
 
         if self._model:
             model = self._model
-            id_value = self._model.get_primary_key_value()
 
         if model and model.is_loaded():
             self.where(model.get_primary_key(), model.get_primary_key_value())


### PR DESCRIPTION
Adds function increment_each. This allows specifying multiple columns to increment by

e.g.

The following will increment the users age by 5 and its children by 10.

User.find(1).increment_each([
 {"age": 5},
 {"children", 10}
])

the result of the action returns either model or a querybuilder

This change also rewrites the original increment function to use the new increment_each function. The function signature remains intact.