### PR TITLE
Adds function value and sole_value to QueryBuilder & Model.

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -265,6 +265,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             "with_count",
             "latest",
             "oldest",
+            "value"
         )
     )
 

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -2277,3 +2277,6 @@ class QueryBuilder(ObservesEvents):
             fields = ("created_at",)
 
         return self.order_by(column=",".join(fields), direction="ASC")
+
+    def value(self, column: str):
+        return self.get().first()[column]

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1749,6 +1749,9 @@ class QueryBuilder(ObservesEvents):
 
         return result.first()
 
+    def sole_value(self, column: str, query=False):
+        return self.sole()[column]
+
     def first_where(self, column, *args):
         """Gets the first record with the given key / value pair"""
         if not args:


### PR DESCRIPTION
Eg. 


remember_token = User.find(1).value("remember_token")

or 

remember_token = User.where("email", "joe@email.com").sole_value("remember_token")