### PR TITLE
Use dynamic model variables for timestamp column names

### DIFF
--- a/src/masoniteorm/scopes/TimeStampsScope.py
+++ b/src/masoniteorm/scopes/TimeStampsScope.py
@@ -1,6 +1,5 @@
-from .BaseScope import BaseScope
-
 from ..expressions.expressions import UpdateQueryExpression
+from .BaseScope import BaseScope
 
 
 class TimeStampsScope(BaseScope):
@@ -27,8 +26,8 @@ class TimeStampsScope(BaseScope):
 
         builder._creates.update(
             {
-                "updated_at": builder._model.get_new_date().to_datetime_string(),
-                "created_at": builder._model.get_new_date().to_datetime_string(),
+                builder._model.date_updated_at: builder._model.get_new_date().to_datetime_string(),
+                builder._model.date_created_at: builder._model.get_new_date().to_datetime_string(),
             }
         )
 
@@ -38,6 +37,8 @@ class TimeStampsScope(BaseScope):
 
         builder._updates += (
             UpdateQueryExpression(
-                {"updated_at": builder._model.get_new_date().to_datetime_string()}
+                {
+                    builder._model.date_updated_at: builder._model.get_new_date().to_datetime_string()
+                }
             ),
         )

--- a/tests/mysql/model/test_model.py
+++ b/tests/mysql/model/test_model.py
@@ -2,10 +2,11 @@ import datetime
 import json
 import os
 import unittest
+
 import pendulum
 
-from src.masoniteorm.exceptions import ModelNotFound
 from src.masoniteorm.collection import Collection
+from src.masoniteorm.exceptions import ModelNotFound
 from src.masoniteorm.models import Model
 from tests.User import User
 


### PR DESCRIPTION
Replaces hardcoded `"created_at"` and `"updated_at"` timestamp column names with base model's `date_created_at` and `date_updated_at` variables. This allows configurability over which columns to use with the timestamps mixin. Besides, if we're already using these variables for date casting, we should also use them in the mixin.