### PR TITLE
Fixed json serialization error if model contains pbjects that are not serializable

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -683,7 +683,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         Returns:
             string
         """
-        return json.dumps(self.serialize())
+        return json.dumps(self.serialize(), default=str)
 
     @classmethod
     def first_or_create(cls, wheres, creates: dict = None):


### PR DESCRIPTION
This fixes the exception when a non serializable object eg Decimal() is an attribute value.

A (possibly) better option would be to use the `simplejson` package for maximum compatibility.
But that is another conversation ;)
  