### PR TITLE
MySQL Close cursor and connection on commit

### DIFF
--- a/src/masoniteorm/connections/MySQLConnection.py
+++ b/src/masoniteorm/connections/MySQLConnection.py
@@ -105,6 +105,9 @@ class MySQLConnection(BaseConnection):
         """Transaction"""
         self._connection.commit()
         self.transaction_level -= 1
+        if self.get_transaction_level() <= 0:
+            self.open = 0
+            self._connection.close()
 
     def dry(self):
         """Transaction"""
@@ -169,6 +172,7 @@ class MySQLConnection(BaseConnection):
         except Exception as e:
             raise QueryException(str(e)) from e
         finally:
+            self._cursor.close()
             if self.get_transaction_level() <= 0:
                 self.open = 0
                 self._connection.close()


### PR DESCRIPTION
Hi @josephmancuso,

I'm having issues with lots of timeouts/open connections, where it seems like the connection isn't being closed.

I was checking MySQLConnection, and I saw that it never closes the cursor, I believe it could cause a memory leak.

I also identified that if I use transactions it will never close the connection, because the code is checking to close the connection in the query function and not in the commit function. Example:

```python
DB.begin_transaction()
QueryBuilder().table('user').update('status', 1)
DB.commit()
```

This is pull request is an idea, I'm happy to discuss any solution.

Thanks.
