### PR TITLE
MSSQL: Fix TypeError: 'NoneType' object is not iterable

### DIFF
--- a/src/masoniteorm/connections/MSSQLConnection.py
+++ b/src/masoniteorm/connections/MSSQLConnection.py
@@ -152,7 +152,7 @@ class MSSQLConnection(BaseConnection):
                         return {}
                     columnNames = [column[0] for column in cursor.description]
                     result = cursor.fetchone()
-                    return dict(zip(columnNames, result))
+                    return dict(zip(columnNames, result)) if result != None else {}
                 else:
                     if not cursor.description:
                         return {}


### PR DESCRIPTION
Scenario:

Get a record(first) and no record in the bank meets the query criteria

result = QueryBuilder.table('a').where('column', aInvalidValue).first()

As the return is null (None) it generates an exception!