### PR TITLE
Adds a create_or_first method to the Model class

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -684,7 +684,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
         """
         return json.dumps(self.serialize(), default=str)
 
-classmethod
+    @classmethod
     def first_or_create(cls, wheres, creates: dict = None):
         """Attempts to find the first record matching the attributes or create it.
 


### PR DESCRIPTION
#### Added

- Adds `create_or_first ` 

#### Changed

- Modified `first_or_create ` to use `create_or_first` under the hood. The goal of this is to eliminate race conditions that can occur when using `first_or_create`. `first_or_create` has also been modified to first look for the first model matching the given criteria if none is found then it calls `create_or_first`. If a unique constraint violation occurs then it tries again to retrieve the model from the database. 


#### Context
Currently, `first_or_create` searches for a model matching the given criteria, if the model does not exist then it creates a new record. A problem can occur where a record is created matching the criteria during the time period between the database read and the database write. This would lead to a `QueryException` due to unique constraint fail. 

What `create_or_first` does is first attempts to create the model. If a unique constraint failure happens then it tries to retrieve the model from the database matching the values of the where clause. 

Both methods take matching arguments.

```python
create_or_first(wheres, creates)
first_or_create(wheres, creates):
```


This is useful in very busy/high concurrency environments where race conditions are more likely. 