### PR TITLE
Added only to Model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="2.19.2",
+    version="2.20.0",
     package_dir={"": "src"},
     description="The Official Masonite ORM",
     long_description=long_description,

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -5,7 +5,7 @@ from datetime import date as datetimedate
 from datetime import datetime
 from datetime import time as datetimetime
 from decimal import Decimal
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import pendulum
 from inflection import tableize, underscore
@@ -810,7 +810,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         return None
 
-    def only(self, attributes: List[str]) -> dict:
+    def only(self, attributes) -> dict:
         results: dict[str, Any] = {}
         for attribute in attributes:
             if " as " in attribute:

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -810,6 +810,12 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         return None
 
+    def only(self, attributes: list[str]):
+        results: dict[str, Any] = {}
+        for attribute in attributes:
+            results[attribute] = self.get_raw_attribute(attribute)
+        return results
+
     def __setattr__(self, attribute, value):
         if hasattr(self, "set_" + attribute + "_attribute"):
             method = getattr(self, "set_" + attribute + "_attribute")

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -810,7 +810,9 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         return None
 
-    def only(self, attributes) -> dict:
+    def only(self, attributes: list) -> dict:
+        if isinstance(attributes, str):
+            attributes = [attributes]
         results: dict[str, Any] = {}
         for attribute in attributes:
             if " as " in attribute:

--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -5,7 +5,7 @@ from datetime import date as datetimedate
 from datetime import datetime
 from datetime import time as datetimetime
 from decimal import Decimal
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pendulum
 from inflection import tableize, underscore
@@ -810,10 +810,19 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
 
         return None
 
-    def only(self, attributes: list[str]):
+    def only(self, attributes: List[str]) -> dict:
         results: dict[str, Any] = {}
         for attribute in attributes:
-            results[attribute] = self.get_raw_attribute(attribute)
+            if " as " in attribute:
+                attribute, alias = attribute.split(" as ")
+                alias = alias.strip()
+                attribute = attribute.strip()
+            else:
+                alias = attribute.strip()
+                attribute = attribute.strip()
+
+            results[alias] = self.get_raw_attribute(attribute)
+
         return results
 
     def __setattr__(self, attribute, value):

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -186,6 +186,15 @@ class TestModels(unittest.TestCase):
         self.assertIn("username", sql)
         self.assertIn("name", sql)
 
+    def test_only_method(self):
+        model = ModelTestForced.hydrate(
+            {"id": 1, "username": "joe", "name": "Joe", "admin": True}
+        )
+
+        
+        self.assertEquals({"username": "joe"}, model.only("username"))
+        self.assertEquals({"username": "joe"}, model.only(["username"]))
+
     def test_model_update_without_changes_at_all(self):
         model = ModelTest.hydrate(
             {"id": 1, "username": "joe", "name": "Joe", "admin": True}


### PR DESCRIPTION
#### Added 

- Adds only method to model class. This method allows you to get a subset of the model's attributes. 

#### Usage

```python
User.first_or_create(
      {"email": "abc@123.com"},
      {"email": "abc@123.com", "password": "password123"}
  ).only([
      "id",
      "email",
  ])
```

this would return the following

```python
{'id': 1, 'email': 'abc@123.com'}
```

In addition to the above usage, you can also use this as a way to remap data. We can alias attributes so that the results can match its destination. Example usage

```python
User.first_or_create(
      {"email": "abc@123.com"},
      {"email": "abc@123.com", "password": "password123"}
  ).only([
      "id as UserIdentifier",
      "email as EmailAddress",
  ])
``` 
this would return the following

```python
{'UserIdentifier': 2, 'EmailAddress': 'abc@123.com'}
```