### PR TITLE
BaseRelationship: s/self/instance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you are interested in the project then it would be a great idea to read the "
 
 ## Issues
 
-Everything really should start with opening an issue or finding an issue. If you feel you have an idea for how the project can be improved, no matter how small, you should open an issue so we can have an open dicussion with the maintainers of the project.
+Everything really should start with opening an issue or finding an issue. If you feel you have an idea for how the project can be improved, no matter how small, you should open an issue so we can have an open discussion with the maintainers of the project.
 
 We can discuss in that issue the solution to the problem or feature you have. If we do not feel it fits within the project then we will close the issue. Feel free to open a new issue if new information comes up.
 

--- a/src/masoniteorm/relationships/BaseRelationship.py
+++ b/src/masoniteorm/relationships/BaseRelationship.py
@@ -52,7 +52,7 @@ class BaseRelationship:
             object -- Either returns a builder or a hydrated model.
         """
         attribute = self.fn.__name__
-        relationship = self.fn(self)()
+        relationship = self.fn(instance)()
         self.set_keys(instance, attribute)
         self._related_builder = relationship.builder
 

--- a/tests/mssql/builder/test_mssql_query_builder_relationships.py
+++ b/tests/mssql/builder/test_mssql_query_builder_relationships.py
@@ -40,6 +40,14 @@ class User(Model):
     def profile(self):
         return Profile
 
+    @belongs_to("id", "parent_dynamic_id")
+    def parent_dynamic(self):
+        return self.__class__
+
+    @belongs_to("id", "parent_specified_id")
+    def parent_specified(self):
+        return User
+
 
 class BaseTestQueryRelationships(unittest.TestCase):
     maxDiff = None
@@ -61,6 +69,26 @@ class BaseTestQueryRelationships(unittest.TestCase):
             sql,
             """SELECT * FROM [users] WHERE EXISTS ("""
             """SELECT * FROM [articles] WHERE [articles].[user_id] = [users].[id]"""
+            """)""",
+        )
+
+    def test_has_reference_to_self(self):
+        builder = self.get_builder()
+        sql = builder.has("parent_dynamic").to_sql()
+        self.assertEqual(
+            sql,
+            """SELECT * FROM [users] WHERE EXISTS ("""
+            """SELECT * FROM [users] WHERE [users].[parent_dynamic_id] = [users].[id]"""
+            """)""",
+        )
+
+    def test_has_reference_to_self_using_class(self):
+        builder = self.get_builder()
+        sql = builder.has("parent_specified").to_sql()
+        self.assertEqual(
+            sql,
+            """SELECT * FROM [users] WHERE EXISTS ("""
+            """SELECT * FROM [users] WHERE [users].[parent_specified_id] = [users].[id]"""
             """)""",
         )
 

--- a/tests/mysql/model/test_model.py
+++ b/tests/mysql/model/test_model.py
@@ -316,7 +316,7 @@ class TestModel(unittest.TestCase):
         self.assertFalse(hasattr(Profile(), "__password__"))
 
 
-if os.getenv("RUN_MYSQL_DATABASE", None).lower() == "true":
+if os.getenv("RUN_MYSQL_DATABASE", "false").lower() == "true":
 
     class MysqlTestModel(unittest.TestCase):
         # TODO: these tests aren't getting run in CI... is that intentional?


### PR DESCRIPTION
when migrating from Orator to Masonite, several of my relationship methods were not working. Stepping through the code, I found that when referencing the `class` via `self.__class__` inside the `User` class, `self` was an instance of `BelongsTo`, not `User`. This PR aims to pass an instance of `User` instead.

``` Python
class User(Model):

    @belongs_to
    def parent(self):
        # ⚠️ self is an instance of BelongsTo ⚠️ 
        # expecting self to be an instance of User
        return self.__class__
```
