### PR TITLE
Close connection on rollback [MySQL]

### DIFF
--- a/src/masoniteorm/connections/MySQLConnection.py
+++ b/src/masoniteorm/connections/MySQLConnection.py
@@ -124,6 +124,9 @@ class MySQLConnection(BaseConnection):
         """Transaction"""
         self._connection.rollback()
         self.transaction_level -= 1
+        if self.get_transaction_level() <= 0:
+            self.open = 0
+            self._connection.close()
 
     def get_transaction_level(self):
         """Transaction"""


### PR DESCRIPTION
Hey @josephmancuso,

I found out that the rollback command has an issue of keeping the MySql connection open. Similar than #857

```python
DB.begin_transaction()
QueryBuilder().table('user').update('status', 1)
DB.rollback()
```

I added a check to close the connection similar with the commit function.

Thank you.