### PR TITLE
Add configuration option to enable or disable foreign keys check for all 4 types of database connections

### DIFF
--- a/src/masoniteorm/connections/BaseConnection.py
+++ b/src/masoniteorm/connections/BaseConnection.py
@@ -76,3 +76,13 @@ class BaseConnection:
             yield result
 
             result = self.format_cursor_results(self._cursor.fetchmany(amount))
+
+    def enable_disable_foreign_keys(self):
+        foreign_keys = self.full_details.get("foreign_keys")
+        platform = self.get_default_platform()()
+
+        if foreign_keys:
+            self._connection.execute(platform.enable_foreign_key_constraints())
+        elif foreign_keys is not None:
+            self._connection.execute(platform.disable_foreign_key_constraints())
+

--- a/src/masoniteorm/connections/MSSQLConnection.py
+++ b/src/masoniteorm/connections/MSSQLConnection.py
@@ -70,6 +70,8 @@ class MSSQLConnection(BaseConnection):
             autocommit=True,
         )
 
+        self.enable_disable_foreign_keys()
+
         self.open = 1
         return self
 

--- a/src/masoniteorm/connections/MySQLConnection.py
+++ b/src/masoniteorm/connections/MySQLConnection.py
@@ -78,6 +78,9 @@ class MySQLConnection(BaseConnection):
             db=self.database,
             **self.options
         )
+
+        self.enable_disable_foreign_keys()
+
         self.open = 1
 
         return self

--- a/src/masoniteorm/connections/PostgresConnection.py
+++ b/src/masoniteorm/connections/PostgresConnection.py
@@ -69,6 +69,8 @@ class PostgresConnection(BaseConnection):
 
         self._connection.autocommit = True
 
+        self.enable_disable_foreign_keys()
+
         self.open = 1
 
         return self

--- a/src/masoniteorm/connections/SQLiteConnection.py
+++ b/src/masoniteorm/connections/SQLiteConnection.py
@@ -63,6 +63,9 @@ class SQLiteConnection(BaseConnection):
         self._connection.create_function("REGEXP", 2, regexp)
 
         self._connection.row_factory = sqlite3.Row
+
+        self.enable_disable_foreign_keys()
+
         self.open = 1
 
         return self

--- a/tests/integrations/config/database.py
+++ b/tests/integrations/config/database.py
@@ -38,7 +38,7 @@ DATABASES = {
         "log_queries": True,
         "propagate": False,
     },
-    "t": {"driver": "sqlite", "database": "orm.sqlite3", "log_queries": True},
+    "t": {"driver": "sqlite", "database": "orm.sqlite3", "log_queries": True, "foreign_keys": True},
     "devprod": {
         "driver": "mysql",
         "host": os.getenv("MYSQL_DATABASE_HOST"),


### PR DESCRIPTION
**Problem:**
When defining migrations for SQLite and, for example, setting cascading on delete it dosn't work as foreign keys are not enabled. According to documentations https://www.sqlite.org/foreignkeys.html they should be enabled manually.

**Solution:**
To not rely on changes how DBMS handles that now and in the future, developer not can enable / disable foreign keys in database connection explicitly. That now would be possible for all 4 types of database.