### PR TITLE
Fix has one through relationship not working

### DIFF
--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1965,6 +1965,8 @@ class QueryBuilder(ObservesEvents):
     def _map_related(self, related_result, related):
         if related.__class__.__name__ == 'MorphTo':
             return related_result
+        elif related.__class__.__name__ == 'HasOneThrough':
+            return related_result.group_by(related.local_key)
 
         return related_result.group_by(related.foreign_key)
 

--- a/src/masoniteorm/relationships/HasOneThrough.py
+++ b/src/masoniteorm/relationships/HasOneThrough.py
@@ -1,4 +1,3 @@
-from build.lib.masoniteorm.query import QueryBuilder
 from .BaseRelationship import BaseRelationship
 from ..collection import Collection
 

--- a/src/masoniteorm/relationships/HasOneThrough.py
+++ b/src/masoniteorm/relationships/HasOneThrough.py
@@ -1,5 +1,4 @@
 from .BaseRelationship import BaseRelationship
-from ..collection import Collection
 
 
 class HasOneThrough(BaseRelationship):
@@ -26,6 +25,10 @@ class HasOneThrough(BaseRelationship):
             self.local_owner_key = local_owner_key or "id"
             self.other_owner_key = other_owner_key or "id"
 
+    def __getattr__(self, attribute):
+        relationship = self.fn(self)[1]()
+        return getattr(relationship.builder, attribute)
+
     def set_keys(self, distant_builder, intermediary_builder, attribute):
         self.local_key = self.local_key or "id"
         self.foreign_key = self.foreign_key or f"{attribute}_id"
@@ -34,17 +37,18 @@ class HasOneThrough(BaseRelationship):
         return self
 
     def __get__(self, instance, owner):
-        """This method is called when the decorated method is accessed.
-
-        Arguments:
-            instance {object|None} -- The instance we called.
-                If we didn't call the attribute and only accessed it then this will be None.
-
-            owner {object} -- The current model that the property was accessed on.
-
-        Returns:
-            object -- Either returns a builder or a hydrated model.
         """
+        This method is called when the decorated method is accessed.
+
+        Arguments
+            instance (object|None): The instance we called.
+                If we didn't call the attribute and only accessed it then this will be None.
+            owner (object): The current model that the property was accessed on.
+
+        Returns
+            QueryBuilder|Model: Either returns a builder or a hydrated model.
+        """
+
         attribute = self.fn.__name__
         self.attribute = attribute
         relationship1 = self.fn(self)[0]()
@@ -57,43 +61,60 @@ class HasOneThrough(BaseRelationship):
             if attribute in instance._relationships:
                 return instance._relationships[attribute]
 
-            result = self.apply_query(
+            return self.apply_query(
                 self.distant_builder, self.intermediary_builder, instance
             )
-            return result
         else:
             return self
 
     def apply_query(self, distant_builder, intermediary_builder, owner):
-        """Apply the query and return a dictionary to be hydrated.
-            Used during accessing a relationship on a model
-
-        Arguments:
-            query {oject} -- The relationship object
-            owner {object} -- The current model oject.
-
-        Returns:
-            dict -- A dictionary of data which will be hydrated.
         """
-        # select * from `countries` inner join `ports` on `ports`.`country_id` = `countries`.`country_id` where `ports`.`port_id` is null and `countries`.`deleted_at` is null and `ports`.`deleted_at` is null
-        distant_builder.join(
-            f"{self.intermediary_builder.get_table_name()}",
-            f"{self.intermediary_builder.get_table_name()}.{self.foreign_key}",
-            "=",
-            f"{distant_builder.get_table_name()}.{self.other_owner_key}",
+        Apply the query and return a dict of data for the distant model to be hydrated with.
+
+        Method is used when accessing a relationship on a model if its not
+        already eager loaded
+
+        Arguments
+            distant_builder (QueryBuilder): QueryVuilder attached to the distant table
+            intermediate_builder (QueryBuilder): QueryVuilder attached to the intermesiate (linking) table
+            owner (Any): the model this relationship is starting from
+
+        Returns
+            dict: A dictionary of data which will be hydrated.
+        """
+
+        dist_table = distant_builder.get_table_name()
+        int_table = intermediary_builder.get_table_name()
+
+        return (
+            distant_builder.select(
+                f"{dist_table}.*, {int_table}.{self.local_owner_key} as {self.local_key}"
+            )
+            .join(
+                f"{int_table}",
+                f"{int_table}.{self.foreign_key}",
+                "=",
+                f"{dist_table}.{self.other_owner_key}",
+            )
+            .where(
+                f"{int_table}.{self.local_owner_key}",
+                getattr(owner, self.local_key),
+            )
+            .first()
         )
 
-        return self
-
     def relate(self, related_model):
+        dist_table = self.distant_builder.get_table_name()
+        int_table = self.intermediary_builder.get_table_name()
+
         return self.distant_builder.join(
-            f"{self.intermediary_builder.get_table_name()}",
-            f"{self.intermediary_builder.get_table_name()}.{self.foreign_key}",
+            f"{int_table}",
+            f"{int_table}.{self.foreign_key}",
             "=",
-            f"{self.distant_builder.get_table_name()}.{self.other_owner_key}",
-        ).where(
-            f"{self.intermediary_builder.get_table_name()}.{self.local_key}",
-            getattr(related_model, self.local_owner_key),
+            f"{dist_table}.{self.other_owner_key}",
+        ).where_column(
+            f"{int_table}.{self.local_owner_key}",
+            f"{query.get_table_name()}.{self.local_key}",
         )
 
     def get_builder(self):
@@ -104,42 +125,83 @@ class HasOneThrough(BaseRelationship):
 
         return builder
 
+    def register_related(self, key, model, collection):
+        """
+        Attach the related model to source models attribute
+
+        Arguments
+            key (str): The attribute name
+            model (Any): The model instance
+            collection (Collection): The data for the related models
+
+        Returns
+            None
+        """
+
+        related = collection.get(getattr(model, self.local_key), None)
+        model.add_relation({key: related[0] if related else None})
+
     def get_related(self, query, relation, eagers=None, callback=None):
-        builder = self.distant_builder
+        """
+        Get the data to htdrate the model for the distant table with
+        Used when eager loading the model attribute
+
+        Arguments
+            query (QueryBuilder): The source models QueryBuilder object
+            relation (HasOneThrough): this relationship object
+            eagers (Any):
+            callback (Any):
+
+        Returns
+             dict: the dict to hydrate the distant model with
+        """
+
+        dist_table = self.distant_builder.get_table_name()
+        int_table = self.intermediary_builder.get_table_name()
 
         if callback:
             callback(builder)
 
-        if isinstance(relation, Collection):
-            return builder.where_in(
-                f"{builder.get_table_name()}.{self.foreign_key}",
-                Collection(relation._get_value(self.local_key)).unique(),
-            ).get()
-        else:
-            return builder.where(
-                f"{builder.get_table_name()}.{self.foreign_key}",
-                getattr(relation, self.local_owner_key),
-            ).first()
+        return (
+            self.distant_builder.select(
+                f"{dist_table}.*, {int_table}.{self.local_owner_key} as {self.local_key}"
+            )
+            .join(
+                f"{int_table}",
+                f"{int_table}.{self.foreign_key}",
+                "=",
+                f"{dist_table}.{self.other_owner_key}",
+            )
+            .where(
+                f"{int_table}.{self.local_owner_key}",
+                relation._get_value(self.local_key),
+            )
+            .get()
+        )
 
     def query_where_exists(
         self, current_query_builder, callback, method="where_exists"
     ):
         query = self.distant_builder
+        dist_table = self.distant_builder.get_table_name()
+        int_table = self.intermediary_builder.get_table_name()
 
         getattr(current_query_builder, method)(
             query.join(
-                f"{self.intermediary_builder.get_table_name()}",
-                f"{self.intermediary_builder.get_table_name()}.{self.foreign_key}",
+                f"{int_table}",
+                f"{int_table}.{self.foreign_key}",
                 "=",
-                f"{query.get_table_name()}.{self.other_owner_key}",
+                f"{dist_table}.{self.other_owner_key}",
             ).where_column(
-                f"{current_query_builder.get_table_name()}.{self.local_owner_key}",
-                f"{self.intermediary_builder.get_table_name()}.{self.local_key}",
+                f"{int_table}.{self.local_owner_key}",
+                f"{query.get_table_name()}.{self.local_key}",
             )
         ).when(callback, lambda q: (callback(q)))
 
     def get_with_count_query(self, builder, callback):
         query = self.distant_builder
+        dist_table = self.distant_builder.get_table_name()
+        int_table = self.intermediary_builder.get_table_name()
 
         if not builder._columns:
             builder = builder.select("*")
@@ -150,16 +212,16 @@ class HasOneThrough(BaseRelationship):
                 (
                     q.count("*")
                     .join(
-                        f"{self.intermediary_builder.get_table_name()}",
-                        f"{self.intermediary_builder.get_table_name()}.{self.foreign_key}",
+                        f"{int_table}",
+                        f"{int_table}.{self.foreign_key}",
                         "=",
-                        f"{query.get_table_name()}.{self.other_owner_key}",
+                        f"{dist_table}.{self.other_owner_key}",
                     )
                     .where_column(
-                        f"{builder.get_table_name()}.{self.local_owner_key}",
-                        f"{self.intermediary_builder.get_table_name()}.{self.local_key}",
+                        f"{int_table}.{self.local_owner_key}",
+                        f"{query.get_table_name()}.{self.local_key}",
                     )
-                    .table(query.get_table_name())
+                    .table(dist_table)
                     .when(
                         callback,
                         lambda q: (
@@ -186,18 +248,19 @@ class HasOneThrough(BaseRelationship):
         )
 
     def query_has(self, current_query_builder, method="where_exists"):
-        related_builder = self.get_builder()
+        dist_table = self.distant_builder.get_table_name()
+        int_table = self.intermediary_builder.get_table_name()
 
         getattr(current_query_builder, method)(
-            self.distant_builder.where_column(
-                f"{current_query_builder.get_table_name()}.{self.local_owner_key}",
-                f"{self.intermediary_builder.get_table_name()}.{self.local_key}",
-            ).join(
-                f"{self.intermediary_builder.get_table_name()}",
-                f"{self.intermediary_builder.get_table_name()}.{self.foreign_key}",
+            self.distant_builder.join(
+                f"{int_table}",
+                f"{int_table}.{self.foreign_key}",
                 "=",
-                f"{self.distant_builder.get_table_name()}.{self.other_owner_key}",
+                f"{dist_table}.{self.other_owner_key}",
+            ).where_column(
+                f"{current_query_builder.get_table_name()}.{self.local_key}",
+                f"{int_table}.{self.local_owner_key}",
             )
         )
 
-        return related_builder
+        return self.distant_builder

--- a/src/masoniteorm/relationships/HasOneThrough.py
+++ b/src/masoniteorm/relationships/HasOneThrough.py
@@ -1,4 +1,6 @@
+from build.lib.masoniteorm.query import QueryBuilder
 from .BaseRelationship import BaseRelationship
+from ..collection import Collection
 
 
 class HasOneThrough(BaseRelationship):
@@ -75,8 +77,8 @@ class HasOneThrough(BaseRelationship):
         already eager loaded
 
         Arguments
-            distant_builder (QueryBuilder): QueryVuilder attached to the distant table
-            intermediate_builder (QueryBuilder): QueryVuilder attached to the intermesiate (linking) table
+            distant_builder (QueryBuilder): QueryBuilder attached to the distant table
+            intermediate_builder (QueryBuilder): QueryBuilder attached to the intermediate (linking) table
             owner (Any): the model this relationship is starting from
 
         Returns
@@ -143,7 +145,7 @@ class HasOneThrough(BaseRelationship):
 
     def get_related(self, query, relation, eagers=None, callback=None):
         """
-        Get the data to htdrate the model for the distant table with
+        Get the data to hydrate the model for the distant table with
         Used when eager loading the model attribute
 
         Arguments

--- a/tests/mysql/relationships/test_has_many_through.py
+++ b/tests/mysql/relationships/test_has_many_through.py
@@ -2,10 +2,7 @@ import unittest
 
 from src.masoniteorm.models import Model
 from src.masoniteorm.relationships import (
-    has_one,
-    belongs_to_many,
     has_many_through,
-    has_many,
 )
 from dotenv import load_dotenv
 
@@ -87,12 +84,4 @@ class MySQLRelationships(unittest.TestCase):
         self.assertEqual(
             sql,
             """SELECT * FROM `inbound_shipments` WHERE `inbound_shipments`.`name` = 'Joe' OR NOT EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`) AND `inbound_shipments`.`name` = 'USA'""",
-        )
-
-    def test_has_one_through_with_count(self):
-        sql = InboundShipment.with_count("from_country").to_sql()
-
-        self.assertEqual(
-            sql,
-            """SELECT `inbound_shipments`.*, (SELECT COUNT(*) AS m_count_reserved FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`) AS from_country_count FROM `inbound_shipments`""",
         )

--- a/tests/mysql/relationships/test_has_one_through.py
+++ b/tests/mysql/relationships/test_has_one_through.py
@@ -13,7 +13,7 @@ load_dotenv(".env")
 
 
 class InboundShipment(Model):
-    @has_one_through("port_id", "country_id", "from_port_id", "country_id")
+    @has_one_through(None, "from_port_id", "country_id", "port_id", "country_id")
     def from_country(self):
         return Country, Port
 
@@ -34,7 +34,7 @@ class MySQLRelationships(unittest.TestCase):
 
         self.assertEqual(
             sql,
-            """SELECT * FROM `inbound_shipments` WHERE EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`)""",
+            """SELECT * FROM `inbound_shipments` WHERE EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `ports`.`port_id` = `inbound_shipments`.`from_port_id`)""",
         )
 
     def test_or_has(self):
@@ -42,7 +42,7 @@ class MySQLRelationships(unittest.TestCase):
 
         self.assertEqual(
             sql,
-            """SELECT * FROM `inbound_shipments` WHERE `inbound_shipments`.`name` = 'Joe' OR EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`)""",
+            """SELECT * FROM `inbound_shipments` WHERE `inbound_shipments`.`name` = 'Joe' OR EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `ports`.`port_id` = `inbound_shipments`.`from_port_id`)""",
         )
 
     def test_where_has_query(self):
@@ -52,7 +52,7 @@ class MySQLRelationships(unittest.TestCase):
 
         self.assertEqual(
             sql,
-            """SELECT * FROM `inbound_shipments` WHERE EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`) AND `inbound_shipments`.`name` = 'USA'""",
+            """SELECT * FROM `inbound_shipments` WHERE EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `ports`.`port_id` = `inbound_shipments`.`from_port_id` AND `countries`.`name` = 'USA')""",
         )
 
     def test_or_where_has(self):
@@ -64,7 +64,7 @@ class MySQLRelationships(unittest.TestCase):
 
         self.assertEqual(
             sql,
-            """SELECT * FROM `inbound_shipments` WHERE `inbound_shipments`.`name` = 'Joe' OR EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`) AND `inbound_shipments`.`name` = 'USA'""",
+            """SELECT * FROM `inbound_shipments` WHERE `inbound_shipments`.`name` = 'Joe' OR EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `ports`.`port_id` = `inbound_shipments`.`from_port_id` AND `countries`.`name` = 'USA')""",
         )
 
     def test_doesnt_have(self):
@@ -72,7 +72,7 @@ class MySQLRelationships(unittest.TestCase):
 
         self.assertEqual(
             sql,
-            """SELECT * FROM `inbound_shipments` WHERE NOT EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`)""",
+            """SELECT * FROM `inbound_shipments` WHERE NOT EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `ports`.`port_id` = `inbound_shipments`.`from_port_id`)""",
         )
 
     def test_or_where_doesnt_have(self):
@@ -86,7 +86,7 @@ class MySQLRelationships(unittest.TestCase):
 
         self.assertEqual(
             sql,
-            """SELECT * FROM `inbound_shipments` WHERE `inbound_shipments`.`name` = 'Joe' OR NOT EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`) AND `inbound_shipments`.`name` = 'USA'""",
+            """SELECT * FROM `inbound_shipments` WHERE `inbound_shipments`.`name` = 'Joe' OR NOT EXISTS (SELECT * FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `ports`.`port_id` = `inbound_shipments`.`from_port_id` AND `countries`.`name` = 'USA')""",
         )
 
     def test_has_one_through_with_count(self):
@@ -94,5 +94,5 @@ class MySQLRelationships(unittest.TestCase):
 
         self.assertEqual(
             sql,
-            """SELECT `inbound_shipments`.*, (SELECT COUNT(*) AS m_count_reserved FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `inbound_shipments`.`from_port_id` = `ports`.`port_id`) AS from_country_count FROM `inbound_shipments`""",
+            """SELECT `inbound_shipments`.*, (SELECT COUNT(*) AS m_count_reserved FROM `countries` INNER JOIN `ports` ON `ports`.`country_id` = `countries`.`country_id` WHERE `ports`.`port_id` = `inbound_shipments`.`from_port_id`) AS from_country_count FROM `inbound_shipments`""",
         )

--- a/tests/mysql/relationships/test_has_one_through.py
+++ b/tests/mysql/relationships/test_has_one_through.py
@@ -2,10 +2,7 @@ import unittest
 
 from src.masoniteorm.models import Model
 from src.masoniteorm.relationships import (
-    has_one,
-    belongs_to_many,
     has_one_through,
-    has_many,
 )
 from dotenv import load_dotenv
 
@@ -26,7 +23,7 @@ class Port(Model):
     pass
 
 
-class MySQLRelationships(unittest.TestCase):
+class MySQLHasOneThroughRelationship(unittest.TestCase):
     maxDiff = None
 
     def test_has_query(self):

--- a/tests/sqlite/relationships/test_sqlite_has_through_relationships.py
+++ b/tests/sqlite/relationships/test_sqlite_has_through_relationships.py
@@ -1,0 +1,119 @@
+import unittest
+
+from build.lib.masoniteorm.collection import Collection
+from build.lib.masoniteorm.scopes import scope
+from src.masoniteorm.models import Model
+from src.masoniteorm.relationships import has_one_through
+from tests.integrations.config.database import DB
+from tests.integrations.config.database import DATABASES
+from src.masoniteorm.schema import Schema
+from src.masoniteorm.schema.platforms import SQLitePlatform
+
+
+class Port(Model):
+    __table__ = "ports"
+    __connection__ = "dev"
+    __fillable__ = ["port_id", "name", "port_country_id"]
+
+
+class Country(Model):
+    __table__ = "countries"
+    __connection__ = "dev"
+    __fillable__ = ["country_id", "name"]
+
+
+class IncomingShipment(Model):
+    __table__ = "incoming_shipments"
+    __connection__ = "dev"
+    __fillable__ = ["shipment_id", "name", "from_port_id"]
+
+    @has_one_through(None, "from_port_id", "port_country_id", "port_id", "country_id")
+    def from_country(self):
+        return [Country, Port]
+
+
+class TestRelationships(unittest.TestCase):
+    def setUp(self):
+        self.schema = Schema(
+            connection="dev",
+            connection_details=DATABASES,
+            platform=SQLitePlatform,
+        ).on("dev")
+
+        with self.schema.create_table_if_not_exists("incoming_shipments") as table:
+            table.integer("shipment_id").primary()
+            table.string("name")
+            table.integer("from_port_id")
+
+        with self.schema.create_table_if_not_exists("ports") as table:
+            table.integer("port_id").primary()
+            table.string("name")
+            table.integer("port_country_id")
+
+        with self.schema.create_table_if_not_exists("countries") as table:
+            table.integer("country_id").primary()
+            table.string("name")
+
+        if not Country.count():
+            Country.builder.new().bulk_create(
+                [
+                    {"country_id": 10, "name": "Australia"},
+                    {"country_id": 20, "name": "USA"},
+                    {"country_id": 30, "name": "Canada"},
+                    {"country_id": 40, "name": "United Kingdom"},
+                ]
+            )
+
+        if not Port.count():
+            Port.builder.new().bulk_create(
+                [
+                    {"port_id": 100, "name": "Melbourne", "port_country_id": 10},
+                    {"port_id": 200, "name": "Darwin", "port_country_id": 10},
+                    {"port_id": 300, "name": "South Louisiana", "port_country_id": 20},
+                    {"port_id": 400, "name": "Houston", "port_country_id": 20},
+                    {"port_id": 500, "name": "Montreal", "port_country_id": 30},
+                    {"port_id": 600, "name": "Vancouver", "port_country_id": 30},
+                    {"port_id": 700, "name": "Southampton", "port_country_id": 40},
+                    {"port_id": 800, "name": "London Gateway", "port_country_id": 40},
+                ]
+            )
+
+        if not IncomingShipment.count():
+            IncomingShipment.builder.new().bulk_create(
+                [
+                    {"name": "Bread", "from_port_id": 300},
+                    {"name": "Milk", "from_port_id": 100},
+                    {"name": "Tractor Parts", "from_port_id": 100},
+                    {"name": "Fridges", "from_port_id": 700},
+                    {"name": "Wheat", "from_port_id": 600},
+                    {"name": "Kettles", "from_port_id": 400},
+                    {"name": "Bread", "from_port_id": 700},
+                ]
+            )
+
+    def test_has_one_through_can_eager_load(self):
+        shipments = IncomingShipment.where("name", "Bread").with_("from_country").get()
+        self.assertEqual(shipments.count(), 2)
+
+        shipment1 = shipments.shift()
+        self.assertIsInstance(shipment1.from_country, Country)
+        self.assertEqual(shipment1.from_country.country_id, 20)
+
+        shipment2 = shipments.shift()
+        self.assertIsInstance(shipment2.from_country, Country)
+        self.assertEqual(shipment2.from_country.country_id, 40)
+
+    def test_has_one_through_eager_load_can_be_empty(self):
+        shipments = (
+            IncomingShipment.where("name", "Bread")
+            .with_(
+                "from_country",
+            )
+            .get()
+        )
+        self.assertEqual(shipments.count(), 2)
+
+    def test_has_one_through_can_get_related(self):
+        shipment = IncomingShipment.where("name", "Milk").first()
+        self.assertIsInstance(shipment.from_country, Country)
+        self.assertEqual(shipment.from_country.country_id, 10)

--- a/tests/sqlite/relationships/test_sqlite_has_through_relationships.py
+++ b/tests/sqlite/relationships/test_sqlite_has_through_relationships.py
@@ -1,10 +1,7 @@
 import unittest
 
-from build.lib.masoniteorm.collection import Collection
-from build.lib.masoniteorm.scopes import scope
 from src.masoniteorm.models import Model
 from src.masoniteorm.relationships import has_one_through
-from tests.integrations.config.database import DB
 from tests.integrations.config.database import DATABASES
 from src.masoniteorm.schema import Schema
 from src.masoniteorm.schema.platforms import SQLitePlatform

--- a/tests/sqlite/relationships/test_sqlite_relationships.py
+++ b/tests/sqlite/relationships/test_sqlite_relationships.py
@@ -3,6 +3,7 @@ from src.masoniteorm.models import Model
 from src.masoniteorm.relationships import belongs_to, has_many, has_one, belongs_to_many
 from tests.integrations.config.database import DB
 
+
 class Profile(Model):
     __table__ = "profiles"
     __connection__ = "dev"


### PR DESCRIPTION
This PR fixes multiple issues with the HasOneThrough relationship.

Issues addresses:
- fixed eager loading
- fixed geting model via `related` method
- some queries missing join and incorrect where clauses
- where_xxx would use wrong table or key
- added eager loading and `related` loading tests

Other changes
- Relationship query code much more readable 
- Added more DocStrings