### PR TITLE
Added SSL configuration in PostgresConnection

### DIFF
--- a/src/masoniteorm/connections/PostgresConnection.py
+++ b/src/masoniteorm/connections/PostgresConnection.py
@@ -65,7 +65,7 @@ class PostgresConnection(BaseConnection):
             host=self.host,
             port=self.port,
             options=f"-c search_path={schema}" if schema else None,
-            sslmode=self.options.get("sslmode", "prefer"),
+            sslmode=self.options.get("sslmode"),
             sslcert=self.options.get("sslcert"),
             sslkey=self.options.get("sslkey"),
             sslrootcert=self.options.get("sslrootcert"),

--- a/src/masoniteorm/connections/PostgresConnection.py
+++ b/src/masoniteorm/connections/PostgresConnection.py
@@ -64,7 +64,11 @@ class PostgresConnection(BaseConnection):
             password=self.password,
             host=self.host,
             port=self.port,
-            options=f"-c search_path={schema}" if schema else "",
+            options=f"-c search_path={schema}" if schema else None,
+            sslmode=self.options.get("sslmode", "prefer"),
+            sslcert=self.options.get("sslcert"),
+            sslkey=self.options.get("sslkey"),
+            sslrootcert=self.options.get("sslrootcert"),
         )
 
         self._connection.autocommit = True


### PR DESCRIPTION
Closes #875 

```python
"postgres": {
    "host": "127.0.0.1",
    "driver": "postgres",
    "database": "masonite",
    "user": "root",
    "password": "",
    "port": 5432,
    "log_queries": False,
    "options": {
      "sslmode": "...",
      "sslcert": "...",
      "sslkey": "..."
    }
```
