### PR TITLE
fixed .on_null and .on_not_null had to be last criteria

### DIFF
--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -251,13 +251,13 @@ class BaseGrammar:
                         on_string += f"{keyword} {self._table_column_string(clause.column1)} {clause.equality} {self._table_column_string(clause.column2)} "
                     else:
                         if clause.value_type == "NULL":
-                            sql_string = self.where_null_string()
+                            sql_string = f"{self.where_null_string()} "
                             on_string += sql_string.format(
                                 keyword=keyword,
                                 column=self.process_column(clause.column),
                             )
                         elif clause.value_type == "NOT NULL":
-                            sql_string = self.where_not_null_string()
+                            sql_string = f"{self.where_not_null_string()} "
                             on_string += sql_string.format(
                                 keyword=keyword,
                                 column=self.process_column(clause.column),

--- a/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
+++ b/src/masoniteorm/testing/BaseTestCaseSelectGrammar.py
@@ -340,7 +340,22 @@ class BaseTestCaseSelectGrammar:
         clause = (
             JoinClause("report_groups as rg")
             .on_null("bgt.acct")
+            .or_on_null("bgt.dept")
+            .on_value("rg.abc", 10)
+        )
+        to_sql = self.builder.join(clause).to_sql()
+
+        sql = getattr(
+            self, inspect.currentframe().f_code.co_name.replace("test_", "")
+        )()
+        self.assertEqual(to_sql, sql)
+
+    def test_can_compile_join_clause_with_not_null(self):
+        clause = (
+            JoinClause("report_groups as rg")
+            .on_not_null("bgt.acct")
             .or_on_not_null("bgt.dept")
+            .on_value("rg.abc", 10)
         )
         to_sql = self.builder.join(clause).to_sql()
 

--- a/tests/mssql/grammar/test_mssql_select_grammar.py
+++ b/tests/mssql/grammar/test_mssql_select_grammar.py
@@ -405,11 +405,25 @@ class TestMSSQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         clause = (
             JoinClause("report_groups as rg")
             .on_null("bgt.acct")
-            .or_on_not_null("bgt.dept")
+            .or_on_null("bgt.dept")
+            .on_value("rg.abc", 10)
         )
         builder.join(clause).to_sql()
         """
-        return "SELECT * FROM [users] INNER JOIN [report_groups] AS [rg] ON [acct] IS NULL OR [dept] IS NOT NULL"
+        return "SELECT * FROM [users] INNER JOIN [report_groups] AS [rg] ON [acct] IS NULL OR [dept] IS NULL AND [rg].[abc] = '10'"
+
+    def can_compile_join_clause_with_not_null(self):
+        """
+        builder = self.get_builder()
+        clause = (
+            JoinClause("report_groups as rg")
+            .on_not_null("bgt.acct")
+            .or_on_not_null("bgt.dept")
+            .on_value("rg.abc", 10)
+        )
+        builder.join(clause).to_sql()
+        """
+        return "SELECT * FROM [users] INNER JOIN [report_groups] AS [rg] ON [acct] IS NOT NULL OR [dept] IS NOT NULL AND [rg].[abc] = '10'"
 
     def can_compile_join_clause_with_lambda(self):
         """

--- a/tests/mysql/grammar/test_mysql_select_grammar.py
+++ b/tests/mysql/grammar/test_mysql_select_grammar.py
@@ -395,11 +395,25 @@ class TestMySQLGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         clause = (
             JoinClause("report_groups as rg")
             .on_null("bgt.acct")
-            .or_on_not_null("bgt.dept")
+            .or_on_null("bgt.dept")
+            .on_value("rg.abc", 10)
         )
         builder.join(clause).to_sql()
         """
-        return "SELECT * FROM `users` INNER JOIN `report_groups` AS `rg` ON `acct` IS NULL OR `dept` IS NOT NULL"
+        return "SELECT * FROM `users` INNER JOIN `report_groups` AS `rg` ON `acct` IS NULL OR `dept` IS NULL AND `rg`.`abc` = '10'"
+
+    def can_compile_join_clause_with_not_null(self):
+        """
+        builder = self.get_builder()
+        clause = (
+            JoinClause("report_groups as rg")
+            .on_not_null("bgt.acct")
+            .or_on_not_null("bgt.dept")
+            .on_value("rg.abc", 10)
+        )
+        builder.join(clause).to_sql()
+        """
+        return "SELECT * FROM `users` INNER JOIN `report_groups` AS `rg` ON `acct` IS NOT NULL OR `dept` IS NOT NULL AND `rg`.`abc` = '10'"
 
     def can_compile_join_clause_with_lambda(self):
         """

--- a/tests/postgres/grammar/test_select_grammar.py
+++ b/tests/postgres/grammar/test_select_grammar.py
@@ -410,11 +410,25 @@ class TestPostgresGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         clause = (
             JoinClause("report_groups as rg")
             .on_null("bgt.acct")
-            .or_on_not_null("bgt.dept")
+            .or_on_null("bgt.dept")
+            .on_value("rg.abc", 10)
         )
         builder.join(clause).to_sql()
         """
-        return """SELECT * FROM "users" INNER JOIN "report_groups" AS "rg" ON "acct" IS NULL OR "dept" IS NOT NULL"""
+        return """SELECT * FROM "users" INNER JOIN "report_groups" AS "rg" ON "acct" IS NULL OR "dept" IS NULL AND "rg"."abc" = '10'"""
+
+    def can_compile_join_clause_with_not_null(self):
+        """
+        builder = self.get_builder()
+        clause = (
+            JoinClause("report_groups as rg")
+            .on_not_null("bgt.acct")
+            .or_on_not_null("bgt.dept")
+            .on_value("rg.abc", 10)
+        )
+        builder.join(clause).to_sql()
+        """
+        return """SELECT * FROM "users" INNER JOIN "report_groups" AS "rg" ON "acct" IS NOT NULL OR "dept" IS NOT NULL AND "rg"."abc" = '10'"""
 
     def can_compile_join_clause_with_lambda(self):
         """

--- a/tests/sqlite/grammar/test_sqlite_select_grammar.py
+++ b/tests/sqlite/grammar/test_sqlite_select_grammar.py
@@ -380,11 +380,25 @@ class TestSQLiteGrammar(BaseTestCaseSelectGrammar, unittest.TestCase):
         clause = (
             JoinClause("report_groups as rg")
             .on_null("bgt.acct")
-            .or_on_not_null("bgt.dept")
+            .or_on_null("bgt.dept")
+            .on_value("rg.abc", 10)
         )
         builder.join(clause).to_sql()
         """
-        return """SELECT * FROM "users" INNER JOIN "report_groups" AS "rg" ON "acct" IS NULL OR "dept" IS NOT NULL"""
+        return """SELECT * FROM "users" INNER JOIN "report_groups" AS "rg" ON "acct" IS NULL OR "dept" IS NULL AND "rg"."abc" = '10'"""
+
+    def can_compile_join_clause_with_not_null(self):
+        """
+        builder = self.get_builder()
+        clause = (
+            JoinClause("report_groups as rg")
+            .on_not_null("bgt.acct")
+            .or_on_not_null("bgt.dept")
+            .on_value("rg.abc", 10)
+        )
+        builder.join(clause).to_sql()
+        """
+        return """SELECT * FROM "users" INNER JOIN "report_groups" AS "rg" ON "acct" IS NOT NULL OR "dept" IS NOT NULL AND "rg"."abc" = '10'"""
 
     def can_compile_join_clause_with_lambda(self):
         """


### PR DESCRIPTION
This PR fixes an issue where a join clause like this:
```python
user_join = (
            JoinClause(f"{u_table} as ut")
            .on("user_id", "=", "ut.id")
            .on_value("ut.email", "=", email)
            .on_null("ut.other_id")
            .on_value("ut.active", "=", True)
        )
```
produces a query similar to this:
```sql
SELECT * FROM "my_model" 
    INNER JOIN "user" AS "ut" 
        ON "my_model"."user_id" = "ut"."id" 
        AND "ut"."email" = 'email@fdomain.com' 
        AND "ut"."other_id" IS NULLAND "ut"."active" = 'True' 
```
Notice there is no space between the "IS NULL" and the next "AND" criterua.
This means that currently the .on_null() and .on_not_null() clauses must always be the last criteria
and as such there cannot be more than 1 of either in the join clause.    