### PR TITLE
Added ability so specify default select criteria for Models

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -354,7 +354,10 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             dry=self.__dry__,
         )
 
-        return self.builder.select(*self.__selects__)
+        return self.builder.select(*self.get_selects())
+
+    def get_selects(self):
+        return self.__selects__
 
     @classmethod
     def get_columns(cls):


### PR DESCRIPTION
Based on discussion in #902 

Specify default select criteriaa for the Model by
overriding  get_selects() in the subclass

@josephmancuso 
do we need more tests than this?
ie for all grammars?