### PR TITLE
allow override of model default selects

### DIFF
--- a/src/masoniteorm/models/Model.py
+++ b/src/masoniteorm/models/Model.py
@@ -354,7 +354,7 @@ class Model(TimeStampsMixin, ObservesEvents, metaclass=ModelMeta):
             dry=self.__dry__,
         )
 
-        return self.builder.select(*self.get_selects())
+        return self.builder
 
     def get_selects(self):
         return self.__selects__

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1229,6 +1229,7 @@ class QueryBuilder(ObservesEvents):
         return self
 
     def with_count(self, relationship, callback=None):
+        self.select(*self._model.get_selects())
         return getattr(self._model, relationship).get_with_count_query(
             self, callback=callback
         )
@@ -2067,6 +2068,9 @@ class QueryBuilder(ObservesEvents):
 
         # Either _creates when creating, otherwise use columns
         columns = self._creates or self._columns
+        if not columns and not self._aggregates and self._model:
+            self.select(*self._model.get_selects())
+            columns = self._columns
 
         return self.grammar(
             columns=columns,

--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1,16 +1,16 @@
 import inspect
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Callable
+from typing import Any, Callable, Dict, List, Optional
 
 from ..collection.Collection import Collection
 from ..config import load_config
 from ..exceptions import (
     HTTP404,
     ConnectionNotRegistered,
+    InvalidArgument,
     ModelNotFound,
     MultipleRecordsFound,
-    InvalidArgument,
 )
 from ..expressions.expressions import (
     AggregateExpression,

--- a/src/masoniteorm/query/grammars/BaseGrammar.py
+++ b/src/masoniteorm/query/grammars/BaseGrammar.py
@@ -1,11 +1,11 @@
 import re
 
 from ...expressions.expressions import (
-    SubGroupExpression,
-    SubSelectExpression,
-    SelectExpression,
     JoinClause,
     OnClause,
+    SelectExpression,
+    SubGroupExpression,
+    SubSelectExpression,
 )
 
 

--- a/src/masoniteorm/query/grammars/PostgresGrammar.py
+++ b/src/masoniteorm/query/grammars/PostgresGrammar.py
@@ -1,5 +1,6 @@
-from .BaseGrammar import BaseGrammar
 import re
+
+from .BaseGrammar import BaseGrammar
 
 
 class PostgresGrammar(BaseGrammar):

--- a/src/masoniteorm/query/grammars/SQLiteGrammar.py
+++ b/src/masoniteorm/query/grammars/SQLiteGrammar.py
@@ -1,5 +1,6 @@
-from .BaseGrammar import BaseGrammar
 import re
+
+from .BaseGrammar import BaseGrammar
 
 
 class SQLiteGrammar(BaseGrammar):

--- a/src/masoniteorm/query/grammars/__init__.py
+++ b/src/masoniteorm/query/grammars/__init__.py
@@ -1,4 +1,4 @@
-from .SQLiteGrammar import SQLiteGrammar
-from .PostgresGrammar import PostgresGrammar
-from .MySQLGrammar import MySQLGrammar
 from .MSSQLGrammar import MSSQLGrammar
+from .MySQLGrammar import MySQLGrammar
+from .PostgresGrammar import PostgresGrammar
+from .SQLiteGrammar import SQLiteGrammar

--- a/src/masoniteorm/query/processors/__init__.py
+++ b/src/masoniteorm/query/processors/__init__.py
@@ -1,4 +1,4 @@
+from .MSSQLPostProcessor import MSSQLPostProcessor
 from .MySQLPostProcessor import MySQLPostProcessor
 from .PostgresPostProcessor import PostgresPostProcessor
 from .SQLitePostProcessor import SQLitePostProcessor
-from .MSSQLPostProcessor import MSSQLPostProcessor

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -37,6 +37,7 @@ class ModelTestForced(Model):
     __force_update__ = True
 
 class BaseModel(Model):
+    __dry__ = True
     def get_selects(self):
         return [f"{self.get_table_name()}.*"]
 
@@ -267,9 +268,26 @@ class TestModels(unittest.TestCase):
             """SELECT `users`.* FROM `users`""",
         )
 
-    def test_model_can_add_to_default_select(self):
+    def test_model_can_override_to_default_select(self):
         sql = ModelWithBaseModel.select(["products.name", "products.id", "store.name"]).to_sql()
         self.assertEqual(
             sql,
-            """SELECT `users`.*, `products`.`name`, `products`.`id`, `store`.`name` FROM `users`""",
+            """SELECT `products`.`name`, `products`.`id`, `store`.`name` FROM `users`""",
+        )
+
+    def test_model_can_use_aggregate_funcs_with_default_selects(self):
+        sql = ModelWithBaseModel.count().to_sql()
+        self.assertEqual(
+            sql,
+            """SELECT COUNT(*) AS m_count_reserved FROM `users`""",
+        )
+        sql = ModelWithBaseModel.max("id").to_sql()
+        self.assertEqual(
+            sql,
+            """SELECT MAX(`users`.`id`) AS id FROM `users`""",
+        )
+        sql = ModelWithBaseModel.min("id").to_sql()
+        self.assertEqual(
+            sql,
+            """SELECT MIN(`users`.`id`) AS id FROM `users`""",
         )

--- a/tests/mssql/builder/test_mssql_query_builder_relationships.py
+++ b/tests/mssql/builder/test_mssql_query_builder_relationships.py
@@ -59,7 +59,7 @@ class BaseTestQueryRelationships(unittest.TestCase):
             connection_class=connection,
             connection="mssql",
             table=table,
-            model=User,
+            model=User(),
         )
 
     def test_has(self):

--- a/tests/mysql/builder/test_transactions.py
+++ b/tests/mysql/builder/test_transactions.py
@@ -26,7 +26,7 @@ if os.getenv("RUN_MYSQL_DATABASE", False) == "True":
         pass
         # def get_builder(self, table="users"):
         #     connection = ConnectionFactory().make("default")
-        #     return QueryBuilder(MySQLGrammar, connection, table=table, model=User)
+        #     return QueryBuilder(MySQLGrammar, connection, table=table, model=User())
 
         # def test_can_start_transaction(self, table="users"):
         #     builder = self.get_builder()

--- a/tests/postgres/builder/test_postgres_transaction.py
+++ b/tests/postgres/builder/test_postgres_transaction.py
@@ -25,7 +25,6 @@ if os.getenv("RUN_POSTGRES_DATABASE") == "True":
                 grammar=PostgresGrammar,
                 connection=connection,
                 table=table,
-                # model=User,
                 connection_details=DATABASES,
             ).on("postgres")
 

--- a/tests/sqlite/builder/test_sqlite_builder_insert.py
+++ b/tests/sqlite/builder/test_sqlite_builder_insert.py
@@ -6,8 +6,6 @@ from src.masoniteorm.connections import ConnectionFactory
 from src.masoniteorm.models import Model
 from src.masoniteorm.query import QueryBuilder
 from src.masoniteorm.query.grammars import SQLiteGrammar
-from src.masoniteorm.relationships import belongs_to
-from tests.utils import MockConnectionFactory
 
 
 class User(Model):
@@ -26,7 +24,6 @@ class BaseTestQueryRelationships(unittest.TestCase):
             connection_class=connection,
             connection="dev",
             table=table,
-            # model=User,
             connection_details=DATABASES,
         ).on("dev")
 

--- a/tests/sqlite/builder/test_sqlite_builder_pagination.py
+++ b/tests/sqlite/builder/test_sqlite_builder_pagination.py
@@ -6,8 +6,6 @@ from src.masoniteorm.connections import ConnectionFactory
 from src.masoniteorm.models import Model
 from src.masoniteorm.query import QueryBuilder
 from src.masoniteorm.query.grammars import SQLiteGrammar
-from src.masoniteorm.relationships import belongs_to
-from tests.utils import MockConnectionFactory
 
 
 class User(Model):

--- a/tests/sqlite/builder/test_sqlite_builder_pagination.py
+++ b/tests/sqlite/builder/test_sqlite_builder_pagination.py
@@ -17,7 +17,7 @@ class User(Model):
 class BaseTestQueryRelationships(unittest.TestCase):
     maxDiff = None
 
-    def get_builder(self, table="users", model=User):
+    def get_builder(self, table="users", model=User()):
         connection = ConnectionFactory().make("sqlite")
         return QueryBuilder(
             grammar=SQLiteGrammar,

--- a/tests/sqlite/builder/test_sqlite_query_builder_eager_loading.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder_eager_loading.py
@@ -7,7 +7,6 @@ from src.masoniteorm.models import Model
 from src.masoniteorm.query import QueryBuilder
 from src.masoniteorm.query.grammars import SQLiteGrammar
 from src.masoniteorm.relationships import belongs_to, has_many
-from tests.utils import MockConnectionFactory
 
 
 class Logo(Model):

--- a/tests/sqlite/builder/test_sqlite_query_builder_eager_loading.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder_eager_loading.py
@@ -58,7 +58,7 @@ class EagerUser(Model):
 class BaseTestQueryRelationships(unittest.TestCase):
     maxDiff = None
 
-    def get_builder(self, table="users", model=User):
+    def get_builder(self, table="users", model=User()):
         connection = ConnectionFactory().make("sqlite")
         return QueryBuilder(
             grammar=SQLiteGrammar,

--- a/tests/sqlite/builder/test_sqlite_query_builder_relationships.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder_relationships.py
@@ -1,7 +1,5 @@
-import inspect
 import unittest
 
-from src.masoniteorm.connections import ConnectionFactory
 from src.masoniteorm.models import Model
 from src.masoniteorm.query import QueryBuilder
 from src.masoniteorm.query.grammars import SQLiteGrammar

--- a/tests/sqlite/builder/test_sqlite_query_builder_relationships.py
+++ b/tests/sqlite/builder/test_sqlite_query_builder_relationships.py
@@ -47,7 +47,7 @@ class BaseTestQueryRelationships(unittest.TestCase):
     def get_builder(self, table="users"):
         connection = MockConnectionFactory().make("sqlite")
         return QueryBuilder(
-            grammar=SQLiteGrammar, connection_class=connection, table=table, model=User
+            grammar=SQLiteGrammar, connection_class=connection, table=table, model=User()
         )
 
     def test_has(self):

--- a/tests/sqlite/builder/test_sqlite_transaction.py
+++ b/tests/sqlite/builder/test_sqlite_transaction.py
@@ -1,4 +1,3 @@
-import inspect
 import unittest
 
 from tests.integrations.config.database import DATABASES
@@ -6,8 +5,6 @@ from src.masoniteorm.connections import ConnectionFactory
 from src.masoniteorm.models import Model
 from src.masoniteorm.query import QueryBuilder
 from src.masoniteorm.query.grammars import SQLiteGrammar
-from src.masoniteorm.relationships import belongs_to
-from tests.utils import MockConnectionFactory
 from tests.integrations.config.database import DB
 from src.masoniteorm.collection import Collection
 

--- a/tests/sqlite/builder/test_sqlite_transaction.py
+++ b/tests/sqlite/builder/test_sqlite_transaction.py
@@ -26,7 +26,7 @@ class BaseTestQueryRelationships(unittest.TestCase):
             grammar=SQLiteGrammar,
             connection="dev",
             table=table,
-            model=User,
+            model=User(),
             connection_details=DATABASES,
         ).on("dev")
 


### PR DESCRIPTION
This PR addresses generating queries with cusom select criteria or aggregation while also defining default select criteria in the model

This moves the addition of the default select columns from the creating the initial builder instance in the model  to the querybuilder where checking if the defaults are actually required is done instead. 

Additional Cleanup:
- Removed some unused imports  from tests
- Removed some unused commented out parameters from tests
- Sorted imports on some tests 