### PR TITLE
Add where_not_in to Collection

### DIFF
--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -430,6 +430,13 @@ class Collection:
         return self.__class__(attributes)
 
     def where_in(self, key, args: list) -> "Collection":
+        # Compatibility patch - allow numeric strings to match integers
+        # (if all args are numeric strings)
+        if all(
+                [isinstance(arg, str) and arg.isnumeric() for arg in args]
+        ):
+            return self.where_in(key, [int(arg) for arg in args])
+
         attributes = []
 
         for item in self._items:
@@ -444,13 +451,6 @@ class Collection:
 
             if comparison in args:
                 attributes.append(item)
-
-        # Compatibility patch - allow numeric strings to match integers
-        # (if all args are numeric strings and no matches were found)
-        if len(attributes) == 0 and all(
-            [isinstance(arg, str) and arg.isnumeric() for arg in args]
-        ):
-            return self.where_in(key, [int(arg) for arg in args])
 
         return self.__class__(attributes)
 

--- a/src/masoniteorm/collection/Collection.py
+++ b/src/masoniteorm/collection/Collection.py
@@ -454,6 +454,31 @@ class Collection:
 
         return self.__class__(attributes)
 
+    def where_not_in(self, key, args: list) -> "Collection":
+        # Compatibility patch - allow numeric strings to match integers
+        # (if all args are numeric strings)
+        if all(
+                [isinstance(arg, str) and arg.isnumeric() for arg in args]
+        ):
+            return self.where_not_in(key, [int(arg) for arg in args])
+
+        attributes = []
+
+        for item in self._items:
+            if isinstance(item, dict):
+                if key not in item:
+                    continue
+                comparison = item.get(key)
+            else:
+                if not hasattr(item, key):
+                    continue
+                comparison = getattr(item, key)
+
+            if comparison not in args:
+                attributes.append(item)
+
+        return self.__class__(attributes)
+
     def zip(self, items):
         items = self.__get_items(items)
         if not isinstance(items, list):

--- a/tests/collection/test_collection.py
+++ b/tests/collection/test_collection.py
@@ -64,6 +64,24 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(len(collection.where_in("id", ["3"])), 1)
         self.assertEqual(len(collection.where_in("id", ["4"])), 0)
 
+    def test_where_not_in(self):
+        collection = Collection(
+            [
+                {"id": 1, "name": "Joe"},
+                {"id": 2, "name": "Joe"},
+                {"id": 3, "name": "Bob"},
+            ]
+        )
+        self.assertEqual(len(collection.where_not_in("id", [1, 2])), 1)
+        self.assertEqual(len(collection.where_not_in("id", [3])), 2)
+        self.assertEqual(len(collection.where_not_in("id", [4])), 3)
+
+        self.assertEqual(len(collection.where_not_in("id", ["1", "2"])), 1)
+        self.assertEqual(len(collection.where_not_in("id", ["3"])), 2)
+        self.assertEqual(len(collection.where_not_in("id", ["4"])), 3)
+
+        self.assertEqual(len(collection.where_not_in("name", ["Joe"])), 1)
+
     def test_where_in_bool(self):
         nested_collection = Collection(
             [

--- a/tests/collection/test_collection.py
+++ b/tests/collection/test_collection.py
@@ -64,6 +64,8 @@ class TestCollection(unittest.TestCase):
         self.assertEqual(len(collection.where_in("id", ["3"])), 1)
         self.assertEqual(len(collection.where_in("id", ["4"])), 0)
 
+        self.assertEqual(len(collection.where_in("name", ["Joe"])), 2)
+
     def test_where_not_in(self):
         collection = Collection(
             [


### PR DESCRIPTION
This addresses #917 

This PR adds functionality to Collection to exclude certain items from a Collection

Additional:
changed when the compatibility check for testing a list of integer strings happens in `where_in()`.
Provides better performance as we still only need to check the Collection once.