### PR TITLE
Fix 925

### DIFF
--- a/src/masoniteorm/query/QueryBuilder.py
+++ b/src/masoniteorm/query/QueryBuilder.py
@@ -1792,7 +1792,7 @@ class QueryBuilder(ObservesEvents):
     def _get_eager_load_result(self, related, collection):
         return related.eager_load_from_collection(collection)
 
-    def find(self, record_id, query=False):
+    def find(self, record_id, column=None, query=False):
         """Finds a row by the primary key ID. Requires a model
 
         Arguments:
@@ -1801,14 +1801,23 @@ class QueryBuilder(ObservesEvents):
         Returns:
             Model|None
         """
-        self.where(self._model.get_primary_key(), record_id)
+        if not column:
+            if not self._model:
+                raise InvalidArgument("A colum to search is required")
+
+            column = self._model.get_primary_key()
+
+        if isinstance(record_id, (list, tuple)):
+            self.where_in(column, record_id)
+        else:
+            self.where(column, record_id)
 
         if query:
             return self
 
         return self.first()
 
-    def find_or(self, record_id: int, callback: Callable, args=None):
+    def find_or(self, record_id: int, callback: Callable, args=None, column=None):
         """Finds a row by the primary key ID (Requires a model) or raise a ModelNotFound exception.
 
         Arguments:
@@ -1822,7 +1831,7 @@ class QueryBuilder(ObservesEvents):
         if not callable(callback):
             raise InvalidArgument("A callback must be callable.")
 
-        result = self.find(record_id=record_id)
+        result = self.find(record_id=record_id, column=column)
 
         if not result:
             if not args:
@@ -1832,7 +1841,7 @@ class QueryBuilder(ObservesEvents):
 
         return result
 
-    def find_or_fail(self, record_id):
+    def find_or_fail(self, record_id, column=None):
         """Finds a row by the primary key ID (Requires a model) or raise a ModelNotFound exception.
 
         Arguments:
@@ -1842,14 +1851,14 @@ class QueryBuilder(ObservesEvents):
             Model|ModelNotFound
         """
 
-        result = self.find(record_id=record_id)
+        result = self.find(record_id=record_id, column=column)
 
         if not result:
             raise ModelNotFound()
 
         return result
 
-    def find_or_404(self, record_id):
+    def find_or_404(self, record_id, column=None):
         """Finds a row by the primary key ID (Requires a model) or raise an 404 exception.
 
         Arguments:
@@ -1860,7 +1869,7 @@ class QueryBuilder(ObservesEvents):
         """
 
         try:
-            return self.find_or_fail(record_id)
+            return self.find_or_fail(record_id=record_id, column=column)
         except ModelNotFound:
             raise HTTP404()
 

--- a/tests/mysql/builder/test_query_builder.py
+++ b/tests/mysql/builder/test_query_builder.py
@@ -2,6 +2,7 @@ import datetime
 import inspect
 import unittest
 
+from src.masoniteorm.exceptions import InvalidArgument
 from src.masoniteorm.models import Model
 from src.masoniteorm.query import QueryBuilder
 from src.masoniteorm.query.grammars import MySQLGrammar
@@ -131,6 +132,44 @@ class BaseTestQueryBuilder:
             self, inspect.currentframe().f_code.co_name.replace("test_", "")
         )()
         self.assertEqual(builder.to_sql(), sql)
+
+    def test_find_with_model(self):
+        builder = self.get_builder()
+        builder.find(1000, query=True)
+        sql = '''SELECT * FROM `users` WHERE `users`.`id` = '1000\''''
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_find_with_model_and_list(self):
+        builder = self.get_builder()
+        builder.find([1000, 2000, 3000], query=True)
+        sql = '''SELECT * FROM `users` WHERE `users`.`id` IN ('1000','2000','3000')'''
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_find_with_model_custom_column(self):
+        builder = self.get_builder()
+        builder.find(10, column="age", query=True)
+        sql = '''SELECT * FROM `users` WHERE `users`.`age` = '10\''''
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_find_with_builder(self):
+        builder = self.get_builder()
+        builder._model = None
+        builder.find(10, column="age", query=True)
+        sql = '''SELECT * FROM `users` WHERE `users`.`age` = '10\''''
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_find_with_builder_and_list(self):
+        builder = self.get_builder()
+        builder._model = None
+        builder.find([10, 20, 30], column="age", query=True)
+        sql = '''SELECT * FROM `users` WHERE `users`.`age` IN ('10','20','30')'''
+        self.assertEqual(builder.to_sql(), sql)
+
+    def test_find_with_builder_without_column(self):
+        builder = self.get_builder()
+        builder._model = None
+        with self.assertRaises(InvalidArgument):
+            builder.find(10, query=True)
 
     def test_select(self):
         builder = self.get_builder()


### PR DESCRIPTION
This PR addresses #925 

Iy also fixes using .findxxx methods with a list (or tuple) of values as per the documentation.

As a bonus we can now use `.find(column="xx")` as a shorcut for a basic equality in `.wher()` and `.where_in()`  

example:
```python
user = User.find(10, column="age")
# is equivalent to
user = User.where("age", 10).first()

users = User.find([10, 20, 30], column="age")
# is equivalent to
users = User.where_in("age", [10, 20, 30]).get()
```
Documentation updates will be done if this PR is accepted noting the above shortcuts

