### PR TITLE
Feature/935 for 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ coverage.xml
 .coverage
 *.log
 build
+/.bootstrapped-pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,35 @@ repos:
     rev: 25.1.0
     hooks:
       - id: black
+        exclude: |
+            (?x)^(
+                "/..*"|
+                "/.yml$"|
+                build|.*
+                conda/.*
+            )$
+
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
     hooks:
       - id: isort
+        exclude: |
+            (?x)^(
+                "/..*"|
+                "/.yml$"|
+                build|.*
+                conda/.*
+            )$
+
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.2
     hooks:
       - id: flake8
         additional_dependencies: [Flake8-pyproject]
+        exclude: |
+            (?x)^(
+                "/..*"|
+                "/.yml$"|
+                build|.*
+                conda/.*
+            )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 25.1.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.2
+    hooks:
+      - id: flake8
+        additional_dependencies: [Flake8-pyproject]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,13 @@ repos:
       - id: black
         exclude: |
             (?x)^(
-                "/..*"|
-                "/.yml$"|
-                build|.*
-                conda/.*
-            )$
+                /.git/|
+                /.github/|
+                /.venv/|
+                /venv/|
+                build/|
+                conda/|
+            )
 
   - repo: https://github.com/pycqa/isort
     rev: 6.0.1
@@ -17,11 +19,13 @@ repos:
       - id: isort
         exclude: |
             (?x)^(
-                "/..*"|
-                "/.yml$"|
-                build|.*
-                conda/.*
-            )$
+                /.git/|
+                /.github/|
+                /.venv/|
+                /venv/|
+                build/|
+                conda/|
+            )
 
   - repo: https://github.com/pycqa/flake8
     rev: 7.1.2
@@ -30,8 +34,10 @@ repos:
         additional_dependencies: [Flake8-pyproject]
         exclude: |
             (?x)^(
-                "/..*"|
-                "/.yml$"|
-                build|.*
-                conda/.*
-            )$
+                /.git/|
+                /.github/|
+                /.venv/|
+                /venv/|
+                build/|
+                conda/|
+            )

--- a/makefile
+++ b/makefile
@@ -1,22 +1,26 @@
-init:
-	cp .env-example .env
+init: .env .bootstrapped-pip
+
+.bootstrapped-pip: requirements.txt
 	pip install -r requirements.txt
 	pre-commit install
-	# Create MySQL Database
-	# Create Postgres Database
-test:
+	touch .bootstrapped-pip
+
+.env:
+	cp .env-example .env
+
+# 	Create MySQL Database
+# 	Create Postgres Database
+test: init
 	python -m pytest tests
 ci:
 	make test
+check: format sort lint
 lint:
-	python -m flake8 src/masoniteorm/ --ignore=E501,F401,E203,E128,E402,E731,F821,E712,W503,F811,E231,E702
-format:
-	black src/masoniteorm
-	black tests/
-	make lint
-sort:
-	isort tests
-	isort src/masoniteorm
+	python -m flake8 src/masoniteorm/ --ignore=E501,F401,E203,E128,E402,E731,F821,E712,W503,F811
+format: init
+	black src/masoniteorm tests/
+sort: init
+	isort src/masoniteorm tests/
 coverage:
 	python -m pytest --cov-report term --cov-report xml --cov=src/masoniteorm tests/
 	python -m coveralls

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 init:
 	cp .env-example .env
 	pip install -r requirements.txt
-	pip install .
+	pre-commit install
 	# Create MySQL Database
 	# Create Postgres Database
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.black]
+target-version = ['py38']
+include = [".pyi?$"]
+exclude = [
+    "/.*",
+    "*.yml",
+    "*.json",
+    "/build",
+    "/conda",
+]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+exclude = [
+    "/.*",
+    "/build",
+    "/conda",
+]
+
+[tool.flake8]
+ignore = ['E501', 'E203', 'E128', 'E402', 'E731', 'F821', 'E712', 'W503', 'F811']
+per-file-ignores = [
+    '__init__.py:F401',
+]
+exclude = [
+    "/.*",
+    "/build",
+    "/conda",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,6 @@
 [tool.black]
 target-version = ['py38']
 include = [".pyi?$"]
-exclude = [
-    "/.*",
-    "*.yml",
-    "*.json",
-    "/build",
-    "/conda",
-]
 
 [tool.isort]
 profile = "black"
@@ -16,19 +9,9 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
-exclude = [
-    "/.*",
-    "/build",
-    "/conda",
-]
 
 [tool.flake8]
 ignore = ['E501', 'E203', 'E128', 'E402', 'E731', 'F821', 'E712', 'W503', 'F811']
 per-file-ignores = [
     '__init__.py:F401',
-]
-exclude = [
-    "/.*",
-    "/build",
-    "/conda",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pre-commit
-flake8
+flake8-pyproject
 black
 isort
 faker

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-flake8==3.7.9
-black==19.3b0
+pre-commit
+flake8
+black
+isort
 faker
 pytest
 pytest-cov
 pymysql
-isort
 inflection==0.3.1
 psycopg2-binary
 python-dotenv==0.14.0


### PR DESCRIPTION
Adds pre-commit checks for code cleanliness
implemetation:
- Only staged files are checked
- commit will not complete if there are ANY failures from any of these tools

Notes:
- Black: applies changes automatically and marks them as as unstaged 
- iSort: applies changes automatically and marks them as as unstaged 
- flake8: issues are noted and require manual adjustments to code 