### PR TITLE
Change logged query execution time units

### DIFF
--- a/src/masoniteorm/connections/BaseConnection.py
+++ b/src/masoniteorm/connections/BaseConnection.py
@@ -23,7 +23,7 @@ class BaseConnection:
         logger.propagate = self.full_details.get("propagate", True)
 
         logger.debug(
-            f"Running query {query}, {bindings}. Executed in {query_time}ms",
+            f"Running query {query}, {bindings}. Executed in {query_time}s",
             extra={"query": query, "bindings": bindings, "query_time": query_time},
         )
 


### PR DESCRIPTION
Fix for issue #945.  Make units of time be seconds (instead of milliseconds) when logging the execution time of a query.