### PR TITLE
Fix  schema connection caching

### DIFF
--- a/src/masoniteorm/schema/Schema.py
+++ b/src/masoniteorm/schema/Schema.py
@@ -132,7 +132,7 @@ class Schema:
 
         self._blueprint = Blueprint(
             self.grammar,
-            connection=self.new_connection(),
+            connection=self.get_connection(),
             table=Table(table),
             action="create",
             platform=self.platform,
@@ -148,7 +148,7 @@ class Schema:
 
         self._blueprint = Blueprint(
             self.grammar,
-            connection=self.new_connection(),
+            connection=self.get_connection(),
             table=Table(table),
             action="create_table_if_not_exists",
             platform=self.platform,
@@ -174,7 +174,7 @@ class Schema:
 
         self._blueprint = Blueprint(
             self.grammar,
-            connection=self.new_connection(),
+            connection=self.get_connection(),
             table=TableDiff(table),
             action="alter",
             platform=self.platform,
@@ -248,11 +248,11 @@ class Schema:
             self._sql = sql
             return sql
 
-        return bool(self.new_connection().query(sql, ()))
+        return bool(self.get_connection().query(sql, ()))
 
     def get_columns(self, table, dict=True):
         table = self.platform().get_current_schema(
-            self.new_connection(), table, schema=self.get_schema()
+            self.get_connection(), table, schema=self.get_schema()
         )
         result = {}
         if dict:
@@ -274,7 +274,7 @@ class Schema:
             self._sql = sql
             return sql
 
-        return bool(self.new_connection().query(sql, ()))
+        return bool(self.get_connection().query(sql, ()))
 
     def drop(self, *args, **kwargs):
         return self.drop_table(*args, **kwargs)
@@ -286,7 +286,7 @@ class Schema:
             self._sql = sql
             return sql
 
-        return bool(self.new_connection().query(sql, ()))
+        return bool(self.get_connection().query(sql, ()))
 
     def rename(self, table, new_name):
         sql = self.platform().compile_rename_table(table, new_name)
@@ -295,7 +295,7 @@ class Schema:
             self._sql = sql
             return sql
 
-        return bool(self.new_connection().query(sql, ()))
+        return bool(self.get_connection().query(sql, ()))
 
     def truncate(self, table, foreign_keys=False):
         sql = self.platform().compile_truncate(
@@ -306,7 +306,7 @@ class Schema:
             self._sql = sql
             return sql
 
-        return bool(self.new_connection().query(sql, ()))
+        return bool(self.get_connection().query(sql, ()))
 
     def get_schema(self):
         """Gets the schema set on the migration class"""
@@ -325,7 +325,7 @@ class Schema:
             self._sql = sql
             return sql
 
-        result = self.new_connection().query(sql, ())
+        result = self.get_connection().query(sql, ())
 
         return (
             list(map(lambda t: list(t.values())[0], result)) if result else []
@@ -348,7 +348,7 @@ class Schema:
             self._sql = sql
             return sql
 
-        return bool(self.new_connection().query(sql, ()))
+        return bool(self.get_connection().query(sql, ()))
 
     def enable_foreign_key_constraints(self):
         sql = self.platform().enable_foreign_key_constraints()
@@ -357,7 +357,7 @@ class Schema:
             self._sql = sql
             return sql
 
-        return bool(self.new_connection().query(sql, ()))
+        return bool(self.get_connection().query(sql, ()))
 
     def disable_foreign_key_constraints(self):
         sql = self.platform().disable_foreign_key_constraints()
@@ -366,4 +366,4 @@ class Schema:
             self._sql = sql
             return sql
 
-        return bool(self.new_connection().query(sql, ()))
+        return bool(self.get_connection().query(sql, ()))

--- a/src/masoniteorm/schema/Schema.py
+++ b/src/masoniteorm/schema/Schema.py
@@ -62,6 +62,7 @@ class Schema:
         self._dry = dry
         self.connection = connection
         self.connection_class = connection_class
+        self._connection_driver = None
         self._connection = None
         self.grammar = grammar
         self.platform = platform
@@ -367,3 +368,16 @@ class Schema:
             return sql
 
         return bool(self.get_connection().query(sql, ()))
+
+    def query_builder(self):
+        """Get a query builder for the schema connection"""
+        from ..query import QueryBuilder
+
+        return QueryBuilder(
+            connection=self.connection,
+            connection_class=self.connection_class,
+            connection_driver=self._connection_driver,
+            connection_details=self.connection_details,
+            schema=self.schema,
+            dry=self.dry,
+        )

--- a/src/masoniteorm/schema/Schema.py
+++ b/src/masoniteorm/schema/Schema.py
@@ -212,15 +212,25 @@ class Schema:
         }
 
     def new_connection(self):
+        """Explicitly creates a new connection."""
         if self._dry:
             return
 
-        self._connection = (
+        return (
             self.connection_class(**self.get_connection_information())
             .set_schema(self.schema)
             .make_connection()
         )
 
+    def get_connection(self):
+        """Create"""
+        if self._dry:
+            return
+
+        if self._connection:
+            return self._connection
+
+        self._connection = self.new_connection()
         return self._connection
 
     def has_column(self, table, column, query_only=False):

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -1,5 +1,6 @@
 import unittest
 
+from src.masoniteorm.query import QueryBuilder
 from src.masoniteorm.schema import Schema
 from src.masoniteorm.schema.platforms import SQLitePlatform
 from tests.integrations.config.database import DATABASES
@@ -35,3 +36,8 @@ class TestSchema(unittest.TestCase):
         self.assertIsNotNone(second_connection)
         self.assertEqual(first_connection, second_connection)
         self.assertNotEqual(new_connection, first_connection)
+
+    def test_can_get_query_builder(self):
+        schema = self.get_schema()
+        builder = schema.query_builder()
+        self.assertIsInstance(builder, QueryBuilder)

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -1,0 +1,38 @@
+import unittest
+
+from src.masoniteorm.schema import Schema
+from src.masoniteorm.schema.platforms import SQLitePlatform
+from tests.integrations.config.database import DATABASES
+from tests.utils import MockSQLiteConnection
+
+
+class TestSchema(unittest.TestCase):
+    maxDiff = None
+
+    def get_schema(self):
+        print("in setUp")
+        return Schema(
+            connection="dev",
+            connection_class=MockSQLiteConnection,
+            connection_details=DATABASES,
+            platform=SQLitePlatform,
+        )
+
+    def test_connection_is_cached(self):
+        schema = self.get_schema()
+        first_connection = schema.get_connection()
+        self.assertIsNotNone(first_connection)
+        second_connection = schema.get_connection()
+        self.assertIsNotNone(second_connection)
+        self.assertEqual(first_connection, second_connection)
+
+    def test_new_connection_is_not_cached(self):
+        schema = self.get_schema()
+        first_connection = schema.get_connection()
+        self.assertIsNotNone(first_connection)
+        new_connection = schema.new_connection()
+        self.assertIsNotNone(new_connection)
+        second_connection = schema.get_connection()
+        self.assertIsNotNone(second_connection)
+        self.assertEqual(first_connection, second_connection)
+        self.assertNotEqual(new_connection, first_connection)

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -10,7 +10,6 @@ class TestSchema(unittest.TestCase):
     maxDiff = None
 
     def get_schema(self):
-        print("in setUp")
         return Schema(
             connection="dev",
             connection_class=MockSQLiteConnection,


### PR DESCRIPTION
fixes #958 

added a get_connection() method which returns the current connection object.

Additional: 
added a helper to get a QueryBuilder instance associated with the same connection.
This allows easier usage of arbitrary queries (like DDL and `SET` statements) to be applied during migrations.  

MOTE: new_connection() does not cache the returned connection.
this allows independant connections to be used alongside each other without interaction