### PR TITLE
Change default folder ISSUE #867

### DIFF
--- a/src/masoniteorm/commands/Command.py
+++ b/src/masoniteorm/commands/Command.py
@@ -1,6 +1,44 @@
+from ..config import load_config
+from ..exceptions import ConfigurationNotFound
+from clikit.api.args.exceptions import NoSuchOptionException
 from .CanOverrideConfig import CanOverrideConfig
 from .CanOverrideOptionsDefault import CanOverrideOptionsDefault
 
 
 class Command(CanOverrideOptionsDefault, CanOverrideConfig):
-    pass
+    def _get_config(self):
+        if not hasattr(self, "_orm_config"):
+            try:
+                self._orm_config = load_config(self._get_option_value("config"))
+            except ConfigurationNotFound:
+                self._orm_config = None
+
+        return self._orm_config
+
+    def _get_option_value(self, option_name):
+        try:
+            return self.option(option_name)
+        except NoSuchOptionException:
+            option = self.config.options.get(option_name)
+            if option:
+                return option.default
+
+            return None
+
+    def option_or_config(self, option_name, default, *config_names):
+        value = self._get_option_value(option_name)
+
+        if value != default:
+            return value
+
+        config = self._get_config()
+        if not config:
+            return default
+
+        names = config_names or (option_name.replace("-", "_"),)
+        for name in names:
+            for config_name in (name, name.upper()):
+                if hasattr(config, config_name):
+                    return getattr(config, config_name)
+
+        return default

--- a/src/masoniteorm/commands/MakeMigrationCommand.py
+++ b/src/masoniteorm/commands/MakeMigrationCommand.py
@@ -33,7 +33,12 @@ class MakeMigrationCommand(Command):
             table = tableize(name.replace("create_", "").replace("_table", ""))
             stub_file = "create_migration"
 
-        migration_directory = self.option("directory")
+        migration_directory = self.option_or_config(
+            "directory",
+            "databases/migrations",
+            "MIGRATIONS_DIRECTORY",
+            "migrations_directory",
+        )
 
         with open(
             os.path.join(

--- a/src/masoniteorm/commands/MakeModelCommand.py
+++ b/src/masoniteorm/commands/MakeModelCommand.py
@@ -25,7 +25,9 @@ class MakeModelCommand(Command):
     def handle(self):
         name = self.argument("name")
 
-        model_directory = self.option("directory")
+        model_directory = self.option_or_config(
+            "directory", "app", "MODELS_DIRECTORY", "models_directory"
+        )
 
         with open(
             os.path.join(pathlib.Path(__file__).parent.absolute(), "stubs/model.stub")
@@ -53,7 +55,12 @@ class MakeModelCommand(Command):
 
         self.info(f"Model created: {os.path.join(model_directory, file_name)}")
         if self.option("migration"):
-            migrations_directory = self.option("migrations-directory")
+            migrations_directory = self.option_or_config(
+                "migrations-directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            )
             if self.option("table"):
                 self.call(
                     "migration",
@@ -66,5 +73,10 @@ class MakeModelCommand(Command):
                 )
 
         if self.option("seeder"):
-            directory = self.option("seeders-directory")
+            directory = self.option_or_config(
+                "seeders-directory",
+                "databases/seeds",
+                "SEEDERS_DIRECTORY",
+                "seeders_directory",
+            )
             self.call("seed", f"{self.argument('name')} --directory {directory}")

--- a/src/masoniteorm/commands/MakeSeedCommand.py
+++ b/src/masoniteorm/commands/MakeSeedCommand.py
@@ -20,7 +20,9 @@ class MakeSeedCommand(Command):
         # replace the placeholders of a stub file
         # output the content to a file location
         name = self.argument("name") + "TableSeeder"
-        seed_directory = self.option("directory")
+        seed_directory = self.option_or_config(
+            "directory", "databases/seeds", "SEEDS_DIRECTORY", "seed_directory"
+        )
 
         file_name = underscore(name)
         stub_file = "create_seed"

--- a/src/masoniteorm/commands/MigrateCommand.py
+++ b/src/masoniteorm/commands/MigrateCommand.py
@@ -31,7 +31,12 @@ class MigrateCommand(Command):
         migration = Migration(
             command_class=self,
             connection=self.option("connection"),
-            migration_directory=self.option("directory"),
+            migration_directory=self.option_or_config(
+                "directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            ),
             config_path=self.option("config"),
             schema=self.option("schema"),
         )

--- a/src/masoniteorm/commands/MigrateFreshCommand.py
+++ b/src/masoniteorm/commands/MigrateFreshCommand.py
@@ -20,7 +20,12 @@ class MigrateFreshCommand(Command):
         migration = Migration(
             command_class=self,
             connection=self.option("connection"),
-            migration_directory=self.option("directory"),
+            migration_directory=self.option_or_config(
+                "directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            ),
             config_path=self.option("config"),
             schema=self.option("schema"),
         )
@@ -32,11 +37,11 @@ class MigrateFreshCommand(Command):
         if self.option("seed") == "null":
             self.call(
                 "seed:run",
-                f"None --directory {self.option('seed-directory')} --connection {self.option('connection')}",
+                f"None --directory {self.option_or_config('seed-directory', 'databases/seeds', 'SEEDS_DIRECTORY', 'seed_directory')} --connection {self.option('connection')}",
             )
 
         elif self.option("seed"):
             self.call(
                 "seed:run",
-                f"{self.option('seed')} --directory {self.option('seed-directory')} --connection {self.option('connection')}",
+                f"{self.option('seed')} --directory {self.option_or_config('seed-directory', 'databases/seeds', 'SEEDS_DIRECTORY', 'seed_directory')} --connection {self.option('connection')}",
             )

--- a/src/masoniteorm/commands/MigrateResetCommand.py
+++ b/src/masoniteorm/commands/MigrateResetCommand.py
@@ -17,7 +17,12 @@ class MigrateResetCommand(Command):
         migration = Migration(
             command_class=self,
             connection=self.option("connection"),
-            migration_directory=self.option("directory"),
+            migration_directory=self.option_or_config(
+                "directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            ),
             config_path=self.option("config"),
             schema=self.option("schema"),
         )

--- a/src/masoniteorm/commands/MigrateRollbackCommand.py
+++ b/src/masoniteorm/commands/MigrateRollbackCommand.py
@@ -18,7 +18,12 @@ class MigrateRollbackCommand(Command):
         Migration(
             command_class=self,
             connection=self.option("connection"),
-            migration_directory=self.option("directory"),
+            migration_directory=self.option_or_config(
+                "directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            ),
             config_path=self.option("config"),
             schema=self.option("schema"),
         ).rollback(migration=self.option("migration"), output=self.option("show"))

--- a/src/masoniteorm/commands/MigrateStatusCommand.py
+++ b/src/masoniteorm/commands/MigrateStatusCommand.py
@@ -16,7 +16,12 @@ class MigrateStatusCommand(Command):
         migration = Migration(
             command_class=self,
             connection=self.option("connection"),
-            migration_directory=self.option("directory"),
+            migration_directory=self.option_or_config(
+                "directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            ),
             config_path=self.option("config"),
             schema=self.option("schema"),
         )

--- a/src/masoniteorm/commands/SeedRunCommand.py
+++ b/src/masoniteorm/commands/SeedRunCommand.py
@@ -18,7 +18,12 @@ class SeedRunCommand(Command):
     def handle(self):
         seeder = Seeder(
             dry=self.option("dry"),
-            seed_path=self.option("directory"),
+            seed_path=self.option_or_config(
+                "directory",
+                "databases/seeds",
+                "SEEDS_DIRECTORY",
+                "seed_directory",
+            ),
             connection=self.option("connection"),
         )
 

--- a/tests/commands/test_directory_defaults.py
+++ b/tests/commands/test_directory_defaults.py
@@ -1,0 +1,82 @@
+import os
+import unittest
+
+from src.masoniteorm.commands import (
+    MakeMigrationCommand,
+    MakeModelCommand,
+    MakeSeedCommand,
+    MigrateCommand,
+    SeedRunCommand,
+)
+
+
+class TestDirectoryDefaults(unittest.TestCase):
+    def setUp(self):
+        self.original_db_config_path = os.getenv("DB_CONFIG_PATH")
+        os.environ["DB_CONFIG_PATH"] = "tests/integrations/config/folder_defaults"
+
+    def tearDown(self):
+        if self.original_db_config_path is None:
+            os.environ.pop("DB_CONFIG_PATH", None)
+        else:
+            os.environ["DB_CONFIG_PATH"] = self.original_db_config_path
+
+    def test_make_model_uses_configured_defaults(self):
+        command = MakeModelCommand()
+
+        self.assertEqual(
+            command.option_or_config(
+                "directory", "app", "MODELS_DIRECTORY", "models_directory"
+            ),
+            "custom-app",
+        )
+        self.assertEqual(
+            command.option_or_config(
+                "migrations-directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            ),
+            "custom-databases/migrations",
+        )
+        self.assertEqual(
+            command.option_or_config(
+                "seeders-directory",
+                "databases/seeds",
+                "SEEDERS_DIRECTORY",
+                "seeders_directory",
+            ),
+            "custom-databases/seeds",
+        )
+
+    def test_migration_and_seed_commands_use_configured_defaults(self):
+        self.assertEqual(
+            MigrateCommand().option_or_config(
+                "directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            ),
+            "custom-databases/migrations",
+        )
+        self.assertEqual(
+            MakeMigrationCommand().option_or_config(
+                "directory",
+                "databases/migrations",
+                "MIGRATIONS_DIRECTORY",
+                "migrations_directory",
+            ),
+            "custom-databases/migrations",
+        )
+        self.assertEqual(
+            MakeSeedCommand().option_or_config(
+                "directory", "databases/seeds", "SEEDS_DIRECTORY", "seed_directory"
+            ),
+            "custom-databases/seeds",
+        )
+        self.assertEqual(
+            SeedRunCommand().option_or_config(
+                "directory", "databases/seeds", "SEEDS_DIRECTORY", "seed_directory"
+            ),
+            "custom-databases/seeds",
+        )

--- a/tests/integrations/config/folder_defaults.py
+++ b/tests/integrations/config/folder_defaults.py
@@ -1,0 +1,19 @@
+from src.masoniteorm.connections import ConnectionResolver
+
+
+DATABASES = {
+    "default": "test",
+    "test": {
+        "driver": "sqlite",
+        "database": "orm.sqlite3",
+        "prefix": "",
+        "log_queries": True,
+    },
+}
+
+DB = ConnectionResolver().set_connection_details(DATABASES)
+
+MODELS_DIRECTORY = "custom-app"
+MIGRATIONS_DIRECTORY = "custom-databases/migrations"
+SEEDS_DIRECTORY = "custom-databases/seeds"
+SEEDERS_DIRECTORY = "custom-databases/seeds"


### PR DESCRIPTION
 CLI now supports folder defaults from the ORM config module
Supported config attributes:

- `MODELS_DIRECTORY`
- `MIGRATIONS_DIRECTORY`
- `SEEDS_DIRECTORY`
- `SEEDERS_DIRECTORY`

If one of those attributes is missing, the existing hardcoded fallback is still used:

- models: `app`
- migrations: `databases/migrations`
- seeds: `databases/seeds`


### Compatibility Notes
- Existing commands still work without any config change.
- Passes the targeted testcases
