### PR TITLE
Deprecate this repository: Masonite ORM continues at masonitedev/orm

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -5,76 +5,20 @@ on:
     types: [created]
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:10.8
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          # will assign a random free host port
-          - 5432/tcp
-        # needed because the postgres container does not provide a healthcheck
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-
-      mysql:
-        image: mysql:5.7
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: orm
-        ports:
-          - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-    strategy:
-      matrix:
-        python-version: ["3.12"]
-    name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          make init-ci
-      - name: Test with Pytest and Publish to PYPI
+          python-version: "3.10"
+      - name: Build and publish
         env:
-          POSTGRES_DATABASE_HOST: localhost
-          POSTGRES_DATABASE_DATABASE: postgres
-          POSTGRES_DATABASE_USER: postgres
-          POSTGRES_DATABASE_PASSWORD: postgres
-          POSTGRES_DATABASE_PORT: ${{ job.services.postgres.ports[5432] }}
-          MYSQL_DATABASE_HOST: localhost
-          MYSQL_DATABASE_DATABASE: orm
-          MYSQL_DATABASE_USER: root
-          MYSQL_DATABASE_PORT: ${{ job.services.mysql.ports[3306] }}
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          DB_CONFIG_PATH: tests/integrations/config/database.py
         run: |
-          python orm migrate --connection postgres
-          python orm migrate --connection mysql
-          make publish
-      - name: Discord notification
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-        uses: Ilshidur/action-discord@master
-        with:
-          args: "{{ EVENT_PAYLOAD.repository.full_name }} {{ EVENT_PAYLOAD.release.tag_name }} has been released. Checkout the full release notes here: {{ EVENT_PAYLOAD.release.html_url }}"
-
-  publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: publish-to-conda
-        uses: fcakyon/conda-publish-action@v1.3
-        with:
-          subdir: "conda"
-          anacondatoken: ${{ secrets.ANACONDA_TOKEN }}
-          platforms: "win osx linux"
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+          python setup.py sdist bdist_wheel
+          twine upload dist/*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# ⚠️ This repository is no longer maintained
+
+> **Masonite ORM development continues at [masonitedev/orm](https://github.com/masonitedev/orm).**
+> It is published on PyPI as [**`masonite-framework-orm`**](https://pypi.org/project/masonite-framework-orm/) — imports are unchanged (`from masoniteorm...`).
+> This repository covers `masonite-orm` ≤ 3.0.0, which will receive **no further updates** (including security fixes).
+>
+> - 📖 Documentation: <https://docs.masonite.dev/orm/introduction/>
+>
+> ❤️ In memory of [Joseph "Joe" Mancuso](https://github.com/josephmancuso), creator of Masonite.
+
+---
+
 <p align="center">
   <img src="https://dev-to-uploads.s3.amazonaws.com/uploads/articles/4trhpkkdbbzutc5ufxi9.png" width="160px">
   <h1 align="center">Masonite ORM</h1>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version="3.0.0",
+    version="3.0.0.post1",
     package_dir={"": "src"},
     description="The Official Masonite ORM",
     long_description=long_description,
@@ -39,7 +39,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 7 - Inactive",
         # Indicate who your project is intended for
         "Intended Audience :: Developers",
         "Topic :: Software Development :: Build Tools",

--- a/src/masoniteorm/__init__.py
+++ b/src/masoniteorm/__init__.py
@@ -1,1 +1,12 @@
+import warnings
+
+warnings.warn(
+    "The 'masonite-orm' package is unmaintained and will receive no further "
+    "updates. Masonite ORM continues as 'masonite-framework-orm' "
+    "(https://github.com/masonitedev/orm) — imports are unchanged. "
+    "Documentation: https://docs.masonite.dev",
+    FutureWarning,
+    stacklevel=2,
+)
+
 from .models import Model


### PR DESCRIPTION
Masonite ORM development continues at [masonitedev/orm](https://github.com/masonitedev/orm), published on PyPI as [`masonite-framework-orm`](https://pypi.org/project/masonite-framework-orm/) — **imports are unchanged**.

This PR adds the deprecation banner to the README (and therefore the PyPI page), emits a `FutureWarning` on `import masoniteorm`, bumps to `3.0.0.post1`, marks the package `Development Status :: 7 - Inactive` and hardens the publish workflow. A `v3.0.0.post1` release follows to ship the notice to PyPI.

❤️ In memory of Joe Mancuso.